### PR TITLE
No longer update Responded At when given an invalid incident category (CU-1ae1j60)

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,10 +10,17 @@
       "request": "launch",
       "name": "Mocha All within 'test' folder",
       "program": "${workspaceFolder}/server/node_modules/mocha/bin/_mocha",
-      "args": ["--timeout", "999999", "--require", "${workspaceFolder}/server/test/mochaFixtures.js", "--colors", "${workspaceFolder}/test/**/*"],
+      "args": [
+        "--timeout",
+        "999999",
+        "--require",
+        "${workspaceFolder}/server/test/mochaFixtures.js",
+        "--colors",
+        "${workspaceFolder}/server/test/**/*"
+      ],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen",
-      "envFile": "${workspaceFolder}/.env",
+      "envFile": "${workspaceFolder}/server/.env",
       "env": { "NODE_ENV": "test" }
     },
     {

--- a/server/BraveAlerterConfigurator.js
+++ b/server/BraveAlerterConfigurator.js
@@ -94,7 +94,7 @@ class BraveAlerterConfigurator {
           session.incidentType = incidentTypes[incidentTypeKeys.indexOf(alertSession.incidentCategoryKey)]
         }
 
-        if (alertSession.alertState === CHATBOT_STATE.WAITING_FOR_CATEGORY) {
+        if (alertSession.alertState === CHATBOT_STATE.WAITING_FOR_CATEGORY && session.respondedAt === null) {
           session.respondedAt = await db.getCurrentTime(client)
         }
 

--- a/server/test/unit/BraveAlerterConfiguratorTest/alertSessionChangedCallbackTest.js
+++ b/server/test/unit/BraveAlerterConfiguratorTest/alertSessionChangedCallbackTest.js
@@ -5,7 +5,7 @@ const sinon = require('sinon')
 const sinonChai = require('sinon-chai')
 
 // In-house dependencies
-const { CHATBOT_STATE, AlertSession, helpers } = require('brave-alert-lib')
+const { CHATBOT_STATE, AlertSession, ALERT_TYPE } = require('brave-alert-lib')
 const BraveAlerterConfigurator = require('../../../BraveAlerterConfigurator')
 const db = require('../../../db/db')
 const redis = require('../../../db/redis')
@@ -16,83 +16,104 @@ use(sinonChai)
 
 const sandbox = sinon.createSandbox()
 
+function createTestSession(overrides = {}) {
+  // prettier-ignore
+  return new Session(
+    overrides.id !== undefined ? overrides.id : 'd91593b4-25ce-11ec-9621-0242ac130002',
+    overrides.locationid !== undefined ? overrides.locationid : 'myLocation',
+    overrides.phoneNumber !== undefined ? overrides.phoneNumber : '+15557773333',
+    overrides.chatbotState !== undefined ? overrides.chatbotState : CHATBOT_STATE.COMPLETED,
+    overrides.alertType !== undefined ? overrides.alertType : ALERT_TYPE.SENSOR_STILLNESS,
+    overrides.createdAt !== undefined ? overrides.createdAt : new Date('2021-10-05T20:20:20.000Z'),
+    overrides.updatedAt !== undefined ? overrides.updatedAt : new Date('2021-10-05T20:20:55.000Z'),
+    overrides.incidentType !== undefined ? overrides.incidentType : 'Overdose',
+    overrides.notes !== undefined ? overrides.notes : null,
+    overrides.respondedAt !== undefined ? overrides.respondedAt : new Date('2021-10-05T20:20:33.000Z'),
+  )
+}
+
 describe('BraveAlerterConfigurator.js unit tests: alertSessionChangedCallback', () => {
   beforeEach(() => {
-    this.testClient = 'testClient'
-    this.testSessionId = 'ca6e85b1-0a8c-4e1a-8d1e-7a35f838d7bc'
-    this.testLocationId = 'TEST_LOCATION'
-    this.testCurrentTime = new Date('2020-10-13T14:45.432Z')
+    this.testCurrentTime = new Date('2020-12-25T10:09:08.000Z')
 
-    // Don't call real DB or Redis
-    sandbox.stub(db, 'beginTransaction').returns(this.testClient)
+    sandbox.stub(db, 'beginTransaction')
     sandbox.stub(db, 'saveSession')
-    this.testSession = new Session()
-    this.testSession.locationid = this.testLocationId
-    this.testSession.id = this.testSessionId
-    sandbox.stub(db, 'getSessionWithSessionId').returns(this.testSession)
     sandbox.stub(db, 'commitTransaction')
     sandbox.stub(db, 'getCurrentTime').returns(this.testCurrentTime)
     sandbox.stub(redis, 'addStateMachineData')
-    sandbox.spy(helpers, 'log')
   })
 
   afterEach(() => {
     sandbox.restore()
   })
 
-  describe('if given only a chatbotState', async () => {
-    beforeEach(async () => {
-      const braveAlerterConfigurator = new BraveAlerterConfigurator()
-      const braveAlerter = braveAlerterConfigurator.createBraveAlerter()
-      await braveAlerter.alertSessionChangedCallback(new AlertSession(this.testSessionId, CHATBOT_STATE.WAITING_FOR_REPLY))
-    })
+  it('if given alertState STARTED should update only alertState', async () => {
+    const sessionId = 'ca6e85b1-0a8c-4e1a-8d1e-7a35f838d7bc'
+    sandbox.stub(db, 'getSessionWithSessionId').returns(createTestSession({ id: sessionId }))
 
-    it('should update the chatbotState', () => {
-      this.testSession.chatbotState = CHATBOT_STATE.WAITING_FOR_REPLY
-      this.testSession.incidentType = undefined
-      expect(db.saveSession).to.be.calledWith(this.testSession, this.testClient)
-    })
+    const braveAlerterConfigurator = new BraveAlerterConfigurator()
+    const braveAlerter = braveAlerterConfigurator.createBraveAlerter()
+    await braveAlerter.alertSessionChangedCallback(new AlertSession(sessionId, CHATBOT_STATE.STARTED))
+
+    const expectedSession = createTestSession({ id: sessionId, chatbotState: CHATBOT_STATE.STARTED })
+
+    expect(db.saveSession).to.be.calledWith(expectedSession, sandbox.any)
   })
 
-  describe('if given only the fallbackReturnMessage', async () => {
-    beforeEach(async () => {
-      const braveAlerterConfigurator = new BraveAlerterConfigurator()
-      const braveAlerter = braveAlerterConfigurator.createBraveAlerter()
-      const alertSession = new AlertSession(this.testSessionId)
-      alertSession.fallbackReturnMessage = 'queued'
-      await braveAlerter.alertSessionChangedCallback(alertSession)
-    })
+  it('if given alertState WAITING_FOR_REPLY should update only alertState', async () => {
+    const sessionId = 'ca6e85b1-0a8c-4e1a-8d1e-7a35f838d7bc'
+    sandbox.stub(db, 'getSessionWithSessionId').returns(createTestSession({ id: sessionId }))
 
-    it('should not update the sesssion at all', () => {
-      expect(db.saveSession).not.to.be.called
-    })
+    const braveAlerterConfigurator = new BraveAlerterConfigurator()
+    const braveAlerter = braveAlerterConfigurator.createBraveAlerter()
+    await braveAlerter.alertSessionChangedCallback(new AlertSession(sessionId, CHATBOT_STATE.WAITING_FOR_REPLY))
+
+    const expectedSession = createTestSession({ id: sessionId, chatbotState: CHATBOT_STATE.WAITING_FOR_REPLY })
+
+    expect(db.saveSession).to.be.calledWith(expectedSession, sandbox.any)
   })
 
-  describe('if given a chatbotState and incidentTypeKey', async () => {
-    beforeEach(async () => {
-      const braveAlerterConfigurator = new BraveAlerterConfigurator()
-      const braveAlerter = braveAlerterConfigurator.createBraveAlerter()
-      await braveAlerter.alertSessionChangedCallback(new AlertSession(this.testSessionId, CHATBOT_STATE.COMPLETED, '2'))
-    })
+  it('if given alertState WAITING_FOR_CATEGORY and it has not already been responded to should update alertState and respondedAt', async () => {
+    const sessionId = 'ca6e85b1-0a8c-4e1a-8d1e-7a35f838d7bc'
+    sandbox.stub(db, 'getSessionWithSessionId').returns(createTestSession({ id: sessionId, respondedAt: null }))
 
-    it('should update chatbotState and incidentType', () => {
-      this.testSession.chatbotState = CHATBOT_STATE.COMPLETED
-      this.testSession.incidentType = 'Person responded'
-      expect(db.saveSession).to.be.calledWith(this.testSession, this.testClient)
-    })
+    const braveAlerterConfigurator = new BraveAlerterConfigurator()
+    const braveAlerter = braveAlerterConfigurator.createBraveAlerter()
+    await braveAlerter.alertSessionChangedCallback(new AlertSession(sessionId, CHATBOT_STATE.WAITING_FOR_CATEGORY))
+
+    const expectedSession = createTestSession(
+      createTestSession({ id: sessionId, chatbotState: CHATBOT_STATE.WAITING_FOR_CATEGORY, respondedAt: this.testCurrentTime }),
+    )
+
+    expect(db.saveSession).to.be.calledWith(expectedSession, sandbox.any)
   })
 
-  describe('if given a chatbotState and respondedAt', async () => {
-    beforeEach(async () => {
-      const braveAlerterConfigurator = new BraveAlerterConfigurator()
-      const braveAlerter = braveAlerterConfigurator.createBraveAlerter()
-      await braveAlerter.alertSessionChangedCallback(new AlertSession(this.testSessionId, CHATBOT_STATE.COMPLETED, '2'))
-    })
+  it('if given alertState WAITING_FOR_CATEGORY and it has already been responded to should update alertState but not update respondedAt', async () => {
+    const testRespondedAtTime = new Date('2010-06-06T06:06:06.000Z')
+    const sessionId = 'ca6e85b1-0a8c-4e1a-8d1e-7a35f838d7bc'
+    sandbox.stub(db, 'getSessionWithSessionId').returns(createTestSession({ id: sessionId, respondedAt: testRespondedAtTime }))
 
-    it('should update chatbotState and incidentType', () => {
-      this.testSession.chatbotState = CHATBOT_STATE.WAITING_FOR_CATEGORY
-      this.testSession.respondedAt = this.testCurrentTime
-      expect(db.saveSession).to.be.calledWith(this.testSession, this.testClient)
-    })
+    const braveAlerterConfigurator = new BraveAlerterConfigurator()
+    const braveAlerter = braveAlerterConfigurator.createBraveAlerter()
+    await braveAlerter.alertSessionChangedCallback(new AlertSession(sessionId, CHATBOT_STATE.WAITING_FOR_CATEGORY))
+
+    const expectedSession = createTestSession(
+      createTestSession({ id: sessionId, chatbotState: CHATBOT_STATE.WAITING_FOR_CATEGORY, respondedAt: testRespondedAtTime }),
+    )
+
+    expect(db.saveSession).to.be.calledWith(expectedSession, sandbox.any)
+  })
+
+  it('if given alertState COMPLETED and categoryKey should update alertState and category', async () => {
+    const sessionId = 'ca6e85b1-0a8c-4e1a-8d1e-7a35f838d7bc'
+    sandbox.stub(db, 'getSessionWithSessionId').returns(createTestSession({ id: sessionId }))
+
+    const braveAlerterConfigurator = new BraveAlerterConfigurator()
+    const braveAlerter = braveAlerterConfigurator.createBraveAlerter()
+    await braveAlerter.alertSessionChangedCallback(new AlertSession(sessionId, CHATBOT_STATE.COMPLETED, '1'))
+
+    const expectedSession = createTestSession({ id: sessionId, chatbotState: CHATBOT_STATE.COMPLETED, incidentType: 'No One Inside' })
+
+    expect(db.saveSession).to.be.calledWith(expectedSession, sandbox.any)
   })
 })


### PR DESCRIPTION
- Also updated the tests for this function to better match the tests in
Buttons because I think the Buttons tests were written better for what
ended up being the implementation of this function. The tests that were
here in Sensors looked like they belonged with an older implementation
that we didn't end up using.

## Test plan
- :heavy_check_mark:  Deploy to `dev.sensors.brave.coop`
- :heavy_check_mark: Run the smoke tests
- :heavy_check_mark:  Trigger an alert on my XeThru+Argon device and see the respondedAt value is `null`
   - :heavy_check_mark: Respond 'OK' and see the respondedAt value change to the current time on the Dashboard
   - :heavy_check_mark: Respond to the incident category question with a valid incident category and see the respondedAt value does not change
   - :heavy_check_mark: Respond to the incident category question with an invalid incident category and see the respondedAt value does not change
   - :heavy_check_mark: Do not respond 'OK' to the button press and see that the respondedAt value remains `null` after the reminder message and after the fallback message
- :heavy_check_mark: Trigger an alert on my INS+Boron device and see the respondedAt value is `null`
   - :heavy_check_mark:  Respond 'OK' and see the respondedAt value change to the current time on the Dashboard
   - :heavy_check_mark: Respond to the incident category question with a valid incident category and see the respondedAt value does not change
   - :heavy_check_mark: Respond to the incident category question with an invalid incident category and see the respondedAt value does not change
   - :heavy_check_mark: Do not respond 'OK' to the button press and see that the respondedAt value remains `null` after the reminder message and after the fallback message