### PR TITLE
Add custom sound to push notifications by updating brave-alert-lib (CU-10xfkhr)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ the code was deployed.
 
 ## [Unreleased]
 
+### Added
+
+- Sound effects to push notifications (CU-10xfkhr).
+
 ## [4.2.0] 2021-10-14
 
 ### Added
@@ -30,6 +34,7 @@ the code was deployed.
 - Unit tests for Particle console functions (CU-vbep38).
 
 ### Fixed
+
 - IM21 door sensor signal processing (CU-4avrue).
 
 ## [4.1.0] - 2021-08-30

--- a/server/.env.example
+++ b/server/.env.example
@@ -79,6 +79,12 @@ ONESIGNAL_APP_ID_TEST=guid-here
 # OneSignal App ID from OneSignal --> Settings --> Keys & IDs --> REST API Key
 ONESIGNAL_API_KEY=jumbleOfCharactersHere
 ONESIGNAL_API_KEY_TEST=jumbleOfCharactersHere
+
 # Timeout in seconds for sending alerts when IM21 sensor has low battery
 LOW_BATTERY_ALERT_TIMEOUT = 86400
 LOW_BATTERY_ALERT_TIMEOUT_TEST = 2
+
+# OneSignal Alert Android Category ID
+# Login to our OneSignal Account. Get this value from Settings --> Messaging --> Android Categories --> Alerts and Reminders --> Channel ID
+ONESIGNAL_ALERT_ANDROID_CATEGORY_ID=guid-here
+ONESIGNAL_ALERT_ANDROID_CATEGORY_ID_TEST=android-group-guid

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -700,8 +700,8 @@
       }
     },
     "brave-alert-lib": {
-      "version": "git+https://github.com/bravetechnologycoop/brave-alert-lib.git#35a46cac42fc746b4ee8a173364ff785c39f090d",
-      "from": "git+https://github.com/bravetechnologycoop/brave-alert-lib.git#v6.0.0",
+      "version": "git+https://github.com/bravetechnologycoop/brave-alert-lib.git#e183981fb440b312b21bc1341b05a55e578eda58",
+      "from": "git+https://github.com/bravetechnologycoop/brave-alert-lib.git#v6.1.0",
       "requires": {
         "@sentry/node": "^6.2.5",
         "@sentry/tracing": "^6.2.5",
@@ -4239,9 +4239,9 @@
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
     },
     "twilio": {
-      "version": "3.70.0",
-      "resolved": "https://registry.npmjs.org/twilio/-/twilio-3.70.0.tgz",
-      "integrity": "sha512-GhohvQfP3aHEwiCb6MWqDJ/KeSyFmFwCQtoSuHEwevE7GCxCq6spK36HlCNg3UyTTZNvfdIhN9Sf1wDWeDIbOg==",
+      "version": "3.71.1",
+      "resolved": "https://registry.npmjs.org/twilio/-/twilio-3.71.1.tgz",
+      "integrity": "sha512-P/KFvm33UW15EnpHJKgdTxUa1u6MlR/u+sCVnL4ie2TDRv6t7kX+ieIGQMpH7bP/z7FXkTjEt0lz4M+XJ/XWOg==",
       "requires": {
         "axios": "^0.21.4",
         "dayjs": "^1.8.29",

--- a/server/package.json
+++ b/server/package.json
@@ -19,7 +19,7 @@
     "@sentry/tracing": "^6.2.5",
     "axios": "^0.21.2",
     "body-parser": "^1.19.0",
-    "brave-alert-lib": "https://github.com/bravetechnologycoop/brave-alert-lib#v6.0.0",
+    "brave-alert-lib": "https://github.com/bravetechnologycoop/brave-alert-lib#v6.1.0",
     "chai-datetime": "^1.8.0",
     "cookie-parser": "^1.4.5",
     "cors": "^2.8.5",

--- a/server/sensor-helm-chart/templates/sensor-deployment.yaml
+++ b/server/sensor-helm-chart/templates/sensor-deployment.yaml
@@ -139,6 +139,11 @@ spec:
               secretKeyRef:
                 name: {{ .Values.secretName | quote }}
                 key: LOW_BATTERY_ALERT_TIMEOUT
+          - name: ONESIGNAL_ALERT_ANDROID_CATEGORY_ID
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.secretName | quote }}
+                key: ONESIGNAL_ALERT_ANDROID_CATEGORY_ID
           - name: ENVIRONMENT
             value: {{ include "sensor.fullname" . | quote }}
           - name: RELEASE


### PR DESCRIPTION
## Test Plan
- :heavy_check_mark:  Deploy to `dev.sensors.brave.coop`
- On Android
   - :heavy_check_mark: Custom sound used for push notifications when Alert App is in the foreground
   - :heavy_check_mark:  Custom sound used for push notifications when Alert App is closed
   - :heavy_check_mark:  Custom sound used for push notifications when Alert App is in the background
   - :question:  Custom sound stops when the the app is opened (this seems to work when I use the notification to open it, but not when I open it through the normal app)
- :question: (didn't check on iOS because it should behave the same as Buttons https://github.com/bravetechnologycoop/BraveButtons/pull/121) On iOS
   - :question: Custom sound used for push notifications when Alert App is in the foreground
   - :question: Custom sound used for push notifications when Alert App is closed
   - :question: Custom sound used for push notifications when Alert App is in the background
   - :question: Custom sound stops when the the app is opened