### PR TITLE
add GET /alert/newNotificationsCount endpoint (CU-hjwcwk)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ the code was deployed.
 
 - Sound effects to push notifications (CU-10xfkhr).
 - "Export CSV" button to the Dashboard (CU-1mek79g).
+- `GET /alert/newNotificationsCount` endpoint (CU-hjwcwk).
 
 ## [4.2.0] 2021-10-14
 

--- a/server/.env.example
+++ b/server/.env.example
@@ -30,6 +30,7 @@ PG_PORT_TEST=5432
 
 # The username for logging into the dashboard
 WEB_USERNAME=username
+WEB_USERNAME_TEST=testusername
 
 # Password for logging into the dashboard
 PASSWORD=examplepassword

--- a/server/BraveAlerterConfigurator.js
+++ b/server/BraveAlerterConfigurator.js
@@ -17,7 +17,7 @@ class BraveAlerterConfigurator {
       this.getLocationByAlertApiKey.bind(this),
       this.getActiveAlertsByAlertApiKey.bind(this),
       this.getHistoricAlertsByAlertApiKey.bind(this),
-      () => {},
+      this.getNewNotificationsCountByAlertApiKey.bind(this),
       false,
       this.getReturnMessage.bind(this),
     )
@@ -159,6 +159,11 @@ class BraveAlerterConfigurator {
     }
 
     return historicAlerts.map(this.createHistoricAlertFromRow)
+  }
+
+  async getNewNotificationsCountByAlertApiKey(alertApiKey) {
+    const count = await db.getNewNotificationsCountByAlertApiKey(alertApiKey)
+    return count
   }
 
   getReturnMessage(fromAlertState, toAlertState) {

--- a/server/db/025-add-notifications.sql
+++ b/server/db/025-add-notifications.sql
@@ -1,0 +1,42 @@
+DO $migration$
+    DECLARE migrationId INT;
+    DECLARE lastSuccessfulMigrationId INT;
+BEGIN
+    -- The migration ID of this file
+    migrationId := 25;
+
+    -- Get the migration ID of the last file to be successfully run
+    SELECT MAX(id) INTO lastSuccessfulMigrationId
+    FROM migrations;
+
+    -- Only execute this script if its migration ID is next after the last successful migration ID
+    IF migrationId - lastSuccessfulMigrationId = 1 THEN
+        CREATE TABLE IF NOT EXISTS notifications (
+            id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+            location_id text REFERENCES locations (locationid) NOT NULL,
+            subject text,
+            body text NOT NULL,
+            is_acknowledged boolean NOT NULL default false,
+            created_at timestamptz NOT NULL default now(),
+            updated_at timestamptz NOT NULL default now()
+        );
+        
+        CREATE OR REPLACE FUNCTION trigger_set_timestamp()
+        RETURNS TRIGGER AS $t$
+        BEGIN
+            NEW.updated_at = NOW();
+            RETURN NEW;
+        END;
+        $t$ LANGUAGE plpgsql;
+
+        DROP TRIGGER IF EXISTS set_notifications_timestamp ON notifications;
+
+        CREATE TRIGGER set_notifications_timestamp
+        BEFORE UPDATE ON notifications
+        FOR EACH ROW EXECUTE PROCEDURE trigger_set_timestamp();
+
+        -- Update the migration ID of the last file to be successfully run to the migration ID of this file
+        INSERT INTO migrations (id)
+        VALUES (migrationId);
+    END IF;
+END $migration$;

--- a/server/db/025-add-notifications.sql
+++ b/server/db/025-add-notifications.sql
@@ -13,7 +13,7 @@ BEGIN
     IF migrationId - lastSuccessfulMigrationId = 1 THEN
         CREATE TABLE IF NOT EXISTS notifications (
             id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-            location_id text REFERENCES locations (locationid) NOT NULL,
+            client_id uuid REFERENCES clients (id) NOT NULL,
             subject text,
             body text NOT NULL,
             is_acknowledged boolean NOT NULL default false,

--- a/server/setup_postgresql.sh
+++ b/server/setup_postgresql.sh
@@ -23,3 +23,4 @@ sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DAT
 sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE --set=sslmode=require -f ./db/022-add-siren-particle-id.sql
 sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE --set=sslmode=require -f ./db/023-add-responder-push-id.sql
 sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE --set=sslmode=require -f ./db/024-add-sent-low-battery-alert-at-to-locations.sql
+sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE --set=sslmode=require -f ./db/025-add-notifications.sql

--- a/server/test/integration/BraveAlerterConfiguratorTest/getNewNotificationsCountByAlertApiKeyTest.js
+++ b/server/test/integration/BraveAlerterConfiguratorTest/getNewNotificationsCountByAlertApiKeyTest.js
@@ -12,38 +12,14 @@ describe('BraveAlerterConfigurator.js integration tests: getNewNotificationsCoun
     await db.clearTables()
 
     this.alertApiKey = '00000000-000000000000001'
-    this.locationId = 'asdfasdfasdf'
 
     const client = await testingHelpers.clientFactory(db, { alertApiKey: this.alertApiKey })
 
-    // Insert a location in the DB
-    await db.createLocation(
-      this.locationId, // locationId
-      1, // movementThreshold
-      1, // stillnessTimer
-      1, // durationTimer
-      1, // reminderTimer
-      1, // initialTimer
-      [], // heartbeatAlertRecipients
-      '+12345678900', // twilioNumber
-      [], // fallbackNumbers
-      1, // fallbackTimer
-      'MyLocationName', // displayName
-      'DoorCoreId', // doorCoreId
-      'RadarCoreId', // radarCoreId
-      'XeThru', // radarType
-      true, // isActive
-      false, // firmwareStateMachine
-      'TestSirenId', // sirenParticleId
-      '2021-03-09T19:37:28.176Z', // sentLowBatteryAlertAt
-      client.id, // clientId
-    )
-
     // create 3 new notifications and 1 acknowledged notification
-    await db.createNotification(this.locationId, 'subject', 'body', false)
-    await db.createNotification(this.locationId, 'subject', 'body', false)
-    await db.createNotification(this.locationId, 'subject', 'body', false)
-    await db.createNotification(this.locationId, 'subject', 'body', true)
+    await db.createNotification(client.id, 'subject', 'body', false)
+    await db.createNotification(client.id, 'subject', 'body', false)
+    await db.createNotification(client.id, 'subject', 'body', false)
+    await db.createNotification(client.id, 'subject', 'body', true)
   })
 
   afterEach(async () => {

--- a/server/test/integration/BraveAlerterConfiguratorTest/getNewNotificationsCountByAlertApiKeyTest.js
+++ b/server/test/integration/BraveAlerterConfiguratorTest/getNewNotificationsCountByAlertApiKeyTest.js
@@ -1,0 +1,66 @@
+// Third-party dependencies
+const { expect } = require('chai')
+const { afterEach, beforeEach, describe, it } = require('mocha')
+
+// In-house dependencies
+const BraveAlerterConfigurator = require('../../../BraveAlerterConfigurator')
+const db = require('../../../db/db')
+const testingHelpers = require('../../../testingHelpers')
+
+describe('BraveAlerterConfigurator.js integration tests: getNewNotificationsCountByAlertApiKey', () => {
+  beforeEach(async () => {
+    await db.clearTables()
+
+    this.alertApiKey = '00000000-000000000000001'
+    this.locationId = 'asdfasdfasdf'
+
+    const client = await testingHelpers.clientFactory(db, { alertApiKey: this.alertApiKey })
+
+    // Insert a location in the DB
+    await db.createLocation(
+      this.locationId, // locationId
+      1, // movementThreshold
+      1, // stillnessTimer
+      1, // durationTimer
+      1, // reminderTimer
+      1, // initialTimer
+      [], // heartbeatAlertRecipients
+      '+12345678900', // twilioNumber
+      [], // fallbackNumbers
+      1, // fallbackTimer
+      'MyLocationName', // displayName
+      'DoorCoreId', // doorCoreId
+      'RadarCoreId', // radarCoreId
+      'XeThru', // radarType
+      true, // isActive
+      false, // firmwareStateMachine
+      'TestSirenId', // sirenParticleId
+      '2021-03-09T19:37:28.176Z', // sentLowBatteryAlertAt
+      client.id, // clientId
+    )
+
+    // create 3 new notifications and 1 acknowledged notification
+    await db.createNotification(this.locationId, 'subject', 'body', false)
+    await db.createNotification(this.locationId, 'subject', 'body', false)
+    await db.createNotification(this.locationId, 'subject', 'body', false)
+    await db.createNotification(this.locationId, 'subject', 'body', true)
+  })
+
+  afterEach(async () => {
+    await db.clearTables()
+  })
+
+  it('should properly count notifications that match the api key', async () => {
+    const braveAlerterConfigurator = new BraveAlerterConfigurator()
+    const braveAlerter = braveAlerterConfigurator.createBraveAlerter()
+    const count = await braveAlerter.getNewNotificationsCountByAlertApiKey(this.alertApiKey)
+    expect(count).to.eql(3)
+  })
+
+  it('should not count notifications that do not match the api key', async () => {
+    const braveAlerterConfigurator = new BraveAlerterConfigurator()
+    const braveAlerter = braveAlerterConfigurator.createBraveAlerter()
+    const count = await braveAlerter.getNewNotificationsCountByAlertApiKey('00000000-000000000000000')
+    expect(count).to.eql(0)
+  })
+})


### PR DESCRIPTION
this pull request adds the Sensors backend implementation of the notification counting feature used in the Alert App.

testing notes:

- the automated tests passed on Travis when I pushed the branch
- I tested this on an Android emulator connected to the Sensors dev environment and everything seemed to work as expected.