### PR TITLE
Change branch names to match preferred branching scheme (CU-mn5q4g)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 Please note that the date associated with a release is the date the code
-was committed to the `master` branch. This is not necessarily the date that
+was committed to the `production` branch. This is not necessarily the date that
 the code was deployed.
 
 ## [Unreleased]
@@ -22,6 +22,10 @@ the code was deployed.
 - Sound effects to push notifications (CU-10xfkhr).
 - "Export CSV" button to the Dashboard (CU-1mek79g).
 - `GET /alert/newNotificationsCount` endpoint (CU-hjwcwk).
+
+### Changed
+
+- Branching scheme (CU-mn5q4g).
 
 ## [4.2.0] 2021-10-14
 

--- a/server/README.md
+++ b/server/README.md
@@ -1,6 +1,6 @@
 # BraveSensor
 
-[![Build Status](https://travis-ci.com/bravetechnologycoop/BraveSensor.svg?branch=master)](https://travis-ci.com/bravetechnologycoop/BraveSensor)
+[![Build Status](https://travis-ci.com/bravetechnologycoop/BraveSensor.svg?branch=main)](https://travis-ci.com/bravetechnologycoop/BraveSensor)
 
 # How to release a new version of BraveSensor Server
 
@@ -8,7 +8,7 @@
 
 1. on your local machine, in the `BraveSensor` repository:
 
-   1. pull the latest code ready for release: `git checkout devenv && git pull origin devenv`
+   1. pull the latest code ready for release: `git checkout main && git pull origin main`
 
    1. decide on an appropriate version number for the new version
 
@@ -22,13 +22,13 @@
 
       1. Update `values.yaml` by putting the tag of your new container image in the `tag` field of `image`
 
-   1. make a new commit directly on `devenv` which updates the changelog and helm chart
+   1. make a new commit directly on `main` which updates the changelog and helm chart
 
    1. tag the new commit - for example, if the version number is v1.0.0, use `git tag v1.0.0`
 
-   1. push the new version to GitHub: `git push origin devenv --tags`
+   1. push the new version to GitHub: `git push origin main --tags`
 
-   1. update the `master` branch: `git checkout master && git merge devenv && git push origin master`
+   1. update the `production` branch: `git checkout production && git merge main && git push origin production`
 
 ## 2. Database changes
 
@@ -72,7 +72,7 @@ We use [helm](https://helm.sh/docs/) to manage our deployments. Helm allows us t
 
 1. Run `ssh brave@sensors-admin.brave.coop`
 
-1. cd into the `~/BraveSensor/server` directory and run `git pull origin master` to get the latest version of the helm chart
+1. cd into the `~/BraveSensor/server` directory and run `git pull origin production` to get the latest version of the helm chart
 
 1. Run the command `helm upgrade staging --set secretName=sensor-dev --set image.tag=<your new container tag> sensor-helm-chart` to deploy the latest version to staging
 


### PR DESCRIPTION
- Renamed `master` --> `production` and `devenv` --> `main`
- Updated README and CHANGELOG accordingly
- Documentation here: https://app.clickup.com/2434616/v/dc/2a9hr-2261/2a9hr-4347

Once this pull request is approved, I will *not* merge it into `devenv`. Instead, I will 
1. Double-check that this branch is up-to-date with `devenv` (if not, then I'll rebase with `devenv`)
2. Update GitHub's default branch to be `main`
3. Change the target of all open pull requests from `devenv` to `main`
4. Create a copy of the `master` branch and name it `production`
5. Delete the `master` and `devenv` branches

Once that is done, then the steps that I suggest everyone does on their local are:
1. Delete the `master` and `devenv` branches
2. Pull the `main` and `production` branches