### PR TITLE
Add an INS firmware state machine smoke test (CU-1tdbnjg)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ the code was deployed.
 
 ## [Unreleased]
 
+### Added
+
+- Innosent firmware state machine smoke test (CU-1tdbnjg).
+
 ## [4.4.0] 2021-12-21
 
 ### Added

--- a/server/README.md
+++ b/server/README.md
@@ -127,9 +127,9 @@ The twilio number must have its SMS webhook pointing at the server you're runnin
 
     `npm run smoketest 'https://staging.sensors.brave.coop' '+17781234567' '+17786083684'`
 
-The script will take a few minutes to conclude. The expected behavior is for a location to be created, and a session which results from a 'Stillness' alert to the phone number provided.
+The script will take a few minutes to conclude. The expected behavior is for a location to be created, and a session which results from a 'Stillness' alert to the phone number provided for a XeThru + Server-side State Machine sensor and then a second time for an INS + Firmware State Machine sensor.
 
-You can get further details about the behavior of the build by watching logs for the application with:
+You can get further details about the behaviour of the build by watching logs for the application with:
 `kubectl logs -f --timestamps deployment/staging-sensor-server`
 and by watching the behavior of redis with:
 `kubectl exec deploy/redis-dev redis-cli monitor`

--- a/server/index.js
+++ b/server/index.js
@@ -18,6 +18,7 @@ const routes = require('./routes')
 const dashboard = require('./dashboard')
 const siren = require('./siren')
 const vitals = require('./vitals')
+const RADAR_TYPE = require('./RadarTypeEnum')
 
 // Start Express App
 const app = express()
@@ -324,7 +325,7 @@ app.post('/smokeTest/setup', async (request, response) => {
       'radar_coreID',
       radarType,
       true,
-      false,
+      radarType === RADAR_TYPE.INNOSENT,
       null,
       '2021-03-09T19:37:28.176Z',
       client.id,


### PR DESCRIPTION
## Test Plan
- :heavy_check_mark: Deploy on Dev
- :heavy_check_mark: Run the smoke tests and do not respond to any texts
   - :heavy_check_mark: Verify that the 'SmokeTestLocation' is configured with XeThru and SSM for the first test
   - :heavy_check_mark: Verify that the 'SmokeTestLocation' is configured with INS and FSM for the first test
   - :heavy_check_mark: Receive texts and see updates as expected in Dashboard and server logs for XeThru + SSM
   - :heavy_check_mark: Receive texts and see updates as expected in Dashboard and server logs for INS + FSM
- :heavy_check_mark: Run the smoke tests and respond to all the texts
   - :heavy_check_mark: Receive texts and see updates as expected in Dashboard and server logs for XeThru + SSM
   - :heavy_check_mark: Receive texts and see updates as expected in Dashboard and server logs for INS + FSM