### PR TITLE
Trim all values when adding or editing Clients and Locations through the API (CU-1pdmvee)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ the code was deployed.
 
 - Innosent firmware state machine smoke test (CU-1tdbnjg).
 
+### Changed
+
+- Trim all values when adding or editing Clients and Locations (CU-1pdmvee).
+
 ## [4.4.0] 2021-12-21
 
 ### Added

--- a/server/Location.js
+++ b/server/Location.js
@@ -1,6 +1,28 @@
 class Location {
-  // prettier-ignore
-  constructor(locationid, displayName, movementThreshold, durationTimer, stillnessTimer, sentVitalsAlertAt, heartbeatAlertRecipients, doorCoreId, radarCoreId, radarType, reminderTimer, fallbackTimer, twilioNumber, fallbackNumbers, initialTimer, isActive, firmwareStateMachine, sirenParticleId, sentLowBatteryAlertAt, client) {
+  constructor(
+    locationid,
+    displayName,
+    movementThreshold,
+    durationTimer,
+    stillnessTimer,
+    sentVitalsAlertAt,
+    heartbeatAlertRecipients,
+    doorCoreId,
+    radarCoreId,
+    radarType,
+    reminderTimer,
+    fallbackTimer,
+    twilioNumber,
+    fallbackNumbers,
+    initialTimer,
+    isActive,
+    firmwareStateMachine,
+    sirenParticleId,
+    sentLowBatteryAlertAt,
+    createdAt,
+    updatedAt,
+    client,
+  ) {
     this.locationid = locationid
     this.displayName = displayName
     this.movementThreshold = movementThreshold
@@ -18,9 +40,11 @@ class Location {
     this.initialTimer = initialTimer
     this.isActive = isActive
     this.firmwareStateMachine = firmwareStateMachine
-    this.client = client
     this.sirenParticleId = sirenParticleId
     this.sentLowBatteryAlertAt = sentLowBatteryAlertAt
+    this.createdAt = createdAt
+    this.updatedAt = updatedAt
+    this.client = client
   }
 }
 

--- a/server/dashboard.js
+++ b/server/dashboard.js
@@ -373,7 +373,7 @@ async function submitNewClient(req, res) {
       res.redirect(`/clients/${newClient.id}`)
     } else {
       const errorMessage = `Bad request to ${req.path}: ${validationErrors.array()}`
-      helpers.logError(errorMessage)
+      helpers.log(errorMessage)
       res.status(400).send(errorMessage)
     }
   } catch (err) {
@@ -418,7 +418,7 @@ async function submitEditClient(req, res) {
       res.redirect(`/clients/${req.params.id}`)
     } else {
       const errorMessage = `Bad request to ${req.path}: ${validationErrors.array()}`
-      helpers.logError(errorMessage)
+      helpers.log(errorMessage)
       res.status(400).send(errorMessage)
     }
   } catch (err) {
@@ -482,7 +482,7 @@ async function submitNewLocation(req, res) {
       res.redirect(`/locations/${data.locationid}`)
     } else {
       const errorMessage = `Bad request to ${req.path}: ${validationErrors.array()}`
-      helpers.logError(errorMessage)
+      helpers.log(errorMessage)
       res.status(400).send(errorMessage)
     }
   } catch (err) {
@@ -556,7 +556,7 @@ async function submitEditLocation(req, res) {
       res.redirect(`/locations/${data.locationid}`)
     } else {
       const errorMessage = `Bad request to ${req.path}: ${validationErrors.array()}`
-      helpers.logError(errorMessage)
+      helpers.log(errorMessage)
       res.status(400).send(errorMessage)
     }
   } catch (err) {

--- a/server/dashboard.js
+++ b/server/dashboard.js
@@ -338,8 +338,8 @@ async function renderClientDetailsPage(req, res) {
 }
 
 const validateNewClient = [
-  Validator.body(['displayName', 'fromPhoneNumber']).notEmpty(),
-  Validator.oneOf([Validator.body(['responderPhoneNumber']).notEmpty(), Validator.body(['alertApiKey', 'responderPushId']).notEmpty()]),
+  Validator.body(['displayName', 'fromPhoneNumber']).trim().notEmpty(),
+  Validator.oneOf([Validator.body(['responderPhoneNumber']).trim().notEmpty(), Validator.body(['alertApiKey', 'responderPushId']).trim().notEmpty()]),
 ]
 
 async function submitNewClient(req, res) {
@@ -383,8 +383,8 @@ async function submitNewClient(req, res) {
 }
 
 const validateEditClient = [
-  Validator.body(['displayName', 'fromPhoneNumber']).notEmpty(),
-  Validator.oneOf([Validator.body(['responderPhoneNumber']).notEmpty(), Validator.body(['alertApiKey', 'responderPushId']).notEmpty()]),
+  Validator.body(['displayName', 'fromPhoneNumber']).trim().notEmpty(),
+  Validator.oneOf([Validator.body(['responderPhoneNumber']).trim().notEmpty(), Validator.body(['alertApiKey', 'responderPushId']).trim().notEmpty()]),
 ]
 
 async function submitEditClient(req, res) {
@@ -436,7 +436,9 @@ const validateNewLocation = Validator.body([
   'twilioPhone',
   'firmwareStateMachine',
   'clientId',
-]).notEmpty()
+])
+  .trim()
+  .notEmpty()
 
 async function submitNewLocation(req, res) {
   try {
@@ -506,7 +508,9 @@ const validateEditLocation = Validator.body([
   'isActive',
   'firmwareStateMachine',
   'clientId',
-]).notEmpty()
+])
+  .trim()
+  .notEmpty()
 
 async function submitEditLocation(req, res) {
   try {
@@ -534,8 +538,8 @@ async function submitEditLocation(req, res) {
         data.doorCoreID,
         data.radarCoreID,
         data.radarType,
-        data.fallbackPhones.split(','),
-        data.heartbeatPhones.split(','),
+        data.fallbackPhones.split(',').map(phone => phone.trim()),
+        data.heartbeatPhones.split(',').map(phone => phone.trim()),
         data.twilioPhone,
         data.movementThreshold,
         data.durationTimer,

--- a/server/db/027-add-location-created-and-updated-dates.sql
+++ b/server/db/027-add-location-created-and-updated-dates.sql
@@ -1,0 +1,39 @@
+DO $migration$
+    DECLARE migrationId INT;
+    DECLARE lastSuccessfulMigrationId INT;
+BEGIN
+    -- The migration ID of this file
+    migrationId := 27;
+
+    -- Get the migration ID of the last file to be successfully run
+    SELECT MAX(id) INTO lastSuccessfulMigrationId
+    FROM migrations;
+
+    -- Only execute this script if its migration ID is next after the last successful migration ID
+    IF migrationId - lastSuccessfulMigrationId = 1 THEN
+        -- Add missing created_at column
+        ALTER TABLE locations
+        ADD COLUMN created_at timestamptz NOT NULL DEFAULT NOW();
+
+        -- Add missing updated_at column
+        ALTER TABLE locations
+        ADD COLUMN updated_at timestamptz NOT NULL DEFAULT NOW();
+
+        -- Add a trigger to update the locations.updated_at column
+        CREATE OR REPLACE FUNCTION trigger_set_timestamp()
+        RETURNS TRIGGER AS $t$
+        BEGIN
+            NEW.updated_at = NOW();
+            RETURN NEW;
+        END;
+        $t$ LANGUAGE plpgsql;
+
+        CREATE TRIGGER set_locations_timestamp
+        BEFORE UPDATE ON locations
+        FOR EACH ROW EXECUTE PROCEDURE trigger_set_timestamp();
+
+        -- Update the migration ID of the last file to be successfully run to the migration ID of this file
+        INSERT INTO migrations (id)
+        VALUES (migrationId);
+    END IF;
+END $migration$;

--- a/server/db/db.js
+++ b/server/db/db.js
@@ -105,7 +105,7 @@ async function createLocationFromRow(r, clientParam) {
     const client = createClientFromRow(results.rows[0])
 
     // prettier-ignore
-    return new Location(r.locationid, r.display_name, r.movement_threshold, r.duration_timer, r.stillness_timer, r.sent_vitals_alert_at, r.heartbeat_alert_recipients, r.door_particlecoreid, r.radar_particlecoreid, r.radar_type, r.reminder_timer, r.fallback_timer, r.twilio_number, r.fallback_phonenumbers, r.initial_timer, r.is_active, r.firmware_state_machine, r.siren_particle_id, r.sent_low_battery_alert_at, client)
+    return new Location(r.locationid, r.display_name, r.movement_threshold, r.duration_timer, r.stillness_timer, r.sent_vitals_alert_at, r.heartbeat_alert_recipients, r.door_particlecoreid, r.radar_particlecoreid, r.radar_type, r.reminder_timer, r.fallback_timer, r.twilio_number, r.fallback_phonenumbers, r.initial_timer, r.is_active, r.firmware_state_machine, r.siren_particle_id, r.sent_low_battery_alert_at, r.created_at, r.updated_at, client)
   } catch (err) {
     helpers.log(err.toString())
   }

--- a/server/mustache-templates/updateClient.mst
+++ b/server/mustache-templates/updateClient.mst
@@ -50,7 +50,7 @@
                 <div class="form-group row justify-content-start row-no-gutters">
                     <label for="responderPushId" class="col-sm-3 col-form-label">Responder Push ID:</label>
                     <div class="col-sm-5">
-                        <input type="text" class="form-control" name="responderPushId" placeholder="Responder Push ID" value={{responderPushId}}>
+                        <input type="text" class="form-control" name="responderPushId" placeholder="Responder Push ID" value="{{responderPushId}}">
                         <small id="responderPushIdHelp" class="form-text text-muted">Must provide either "Responder Phone Number" or ("Responder Push ID" and "Alert App API Key")</small>
                     </div>
                 </div>

--- a/server/setup_postgresql.sh
+++ b/server/setup_postgresql.sh
@@ -25,3 +25,4 @@ sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DAT
 sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE --set=sslmode=require -f ./db/024-add-sent-low-battery-alert-at-to-locations.sql
 sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE --set=sslmode=require -f ./db/025-add-notifications.sql
 sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE --set=sslmode=require -f ./db/026-add-sent-vitals-alert-at.sql
+sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE --set=sslmode=require -f ./db/027-add-location-created-and-updated-dates.sql

--- a/server/test/integration/dashboardTest/submitEditClientTest.js
+++ b/server/test/integration/dashboardTest/submitEditClientTest.js
@@ -360,7 +360,7 @@ describe('dashboard.js integration tests: submitEditClient', () => {
     })
 
     it('should log the error', () => {
-      expect(helpers.logError).to.have.been.calledWith(
+      expect(helpers.log).to.have.been.calledWith(
         `Bad request to /clients/${this.existingClient.id}: responderPhoneNumber/responderPushId (Invalid value(s))`,
       )
     })
@@ -395,7 +395,7 @@ describe('dashboard.js integration tests: submitEditClient', () => {
     })
 
     it('should log the error', () => {
-      expect(helpers.logError).to.have.been.calledWith(
+      expect(helpers.log).to.have.been.calledWith(
         `Bad request to /clients/${this.existingClient.id}: displayName (Invalid value),fromPhoneNumber (Invalid value),responderPhoneNumber/alertApiKey/responderPushId (Invalid value(s))`,
       )
     })
@@ -422,7 +422,7 @@ describe('dashboard.js integration tests: submitEditClient', () => {
     })
 
     it('should log the error', () => {
-      expect(helpers.logError).to.have.been.calledWith(
+      expect(helpers.log).to.have.been.calledWith(
         `Bad request to /clients/${this.existingClient.id}: displayName (Invalid value),fromPhoneNumber (Invalid value),responderPhoneNumber/alertApiKey/responderPushId (Invalid value(s))`,
       )
     })

--- a/server/test/integration/dashboardTest/submitEditLocationTest.js
+++ b/server/test/integration/dashboardTest/submitEditLocationTest.js
@@ -305,7 +305,7 @@ describe('dashboard.js integration tests: submitEditLocation', () => {
     })
 
     it('should log the error', () => {
-      expect(helpers.logError).to.have.been.calledWith(
+      expect(helpers.log).to.have.been.calledWith(
         `Bad request to /locations/test1: displayName (Invalid value),doorCoreID (Invalid value),radarCoreID (Invalid value),radarType (Invalid value),fallbackPhones (Invalid value),heartbeatPhones (Invalid value),twilioPhone (Invalid value),movementThreshold (Invalid value),durationTimer (Invalid value),stillnessTimer (Invalid value),initialTimer (Invalid value),reminderTimer (Invalid value),fallbackTimer (Invalid value),isActive (Invalid value),firmwareStateMachine (Invalid value),clientId (Invalid value)`,
       )
     })
@@ -337,7 +337,7 @@ describe('dashboard.js integration tests: submitEditLocation', () => {
     })
 
     it('should log the error', () => {
-      expect(helpers.logError).to.have.been.calledWith(
+      expect(helpers.log).to.have.been.calledWith(
         `Bad request to /locations/test1: displayName (Invalid value),doorCoreID (Invalid value),radarCoreID (Invalid value),radarType (Invalid value),fallbackPhones (Invalid value),heartbeatPhones (Invalid value),twilioPhone (Invalid value),movementThreshold (Invalid value),durationTimer (Invalid value),stillnessTimer (Invalid value),initialTimer (Invalid value),reminderTimer (Invalid value),fallbackTimer (Invalid value),isActive (Invalid value),firmwareStateMachine (Invalid value),clientId (Invalid value)`,
       )
     })

--- a/server/test/integration/dashboardTest/submitNewClientTest.js
+++ b/server/test/integration/dashboardTest/submitNewClientTest.js
@@ -348,7 +348,7 @@ describe('dashboard.js integration tests: submitNewClient', () => {
     })
 
     it('should log the error', () => {
-      expect(helpers.logError).to.have.been.calledWith('Bad request to /clients: responderPhoneNumber/responderPushId (Invalid value(s))')
+      expect(helpers.log).to.have.been.calledWith('Bad request to /clients: responderPhoneNumber/responderPushId (Invalid value(s))')
     })
   })
 
@@ -378,7 +378,7 @@ describe('dashboard.js integration tests: submitNewClient', () => {
     })
 
     it('should log the error', () => {
-      expect(helpers.logError).to.have.been.calledWith(
+      expect(helpers.log).to.have.been.calledWith(
         'Bad request to /clients: displayName (Invalid value),fromPhoneNumber (Invalid value),responderPhoneNumber/alertApiKey/responderPushId (Invalid value(s))',
       )
     })
@@ -405,7 +405,7 @@ describe('dashboard.js integration tests: submitNewClient', () => {
     })
 
     it('should log the error', () => {
-      expect(helpers.logError).to.have.been.calledWith(
+      expect(helpers.log).to.have.been.calledWith(
         'Bad request to /clients: displayName (Invalid value),fromPhoneNumber (Invalid value),responderPhoneNumber/alertApiKey/responderPushId (Invalid value(s))',
       )
     })

--- a/server/test/integration/dashboardTest/submitNewLocationTest.js
+++ b/server/test/integration/dashboardTest/submitNewLocationTest.js
@@ -251,7 +251,7 @@ describe('dashboard.js integration tests: submitNewLocation', () => {
     })
 
     it('should log the error', () => {
-      expect(helpers.logError).to.have.been.calledWith(
+      expect(helpers.log).to.have.been.calledWith(
         `Bad request to /locations: locationid (Invalid value),displayName (Invalid value),doorCoreID (Invalid value),radarCoreID (Invalid value),radarType (Invalid value),twilioPhone (Invalid value),firmwareStateMachine (Invalid value),clientId (Invalid value)`,
       )
     })
@@ -278,7 +278,7 @@ describe('dashboard.js integration tests: submitNewLocation', () => {
     })
 
     it('should log the error', () => {
-      expect(helpers.logError).to.have.been.calledWith(
+      expect(helpers.log).to.have.been.calledWith(
         `Bad request to /locations: locationid (Invalid value),displayName (Invalid value),doorCoreID (Invalid value),radarCoreID (Invalid value),radarType (Invalid value),twilioPhone (Invalid value),firmwareStateMachine (Invalid value),clientId (Invalid value)`,
       )
     })

--- a/server/test/unit/vitalsTest/checkHeartbeatTest.js
+++ b/server/test/unit/vitalsTest/checkHeartbeatTest.js
@@ -54,9 +54,11 @@ function locationFactory(overrides = {}) {
     overrides.initialTimer !== undefined ? overrides.initialTimer : 1,
     overrides.isActive !== undefined ? overrides.isActive : true,
     overrides.firmwareStateMachine !== undefined ? overrides.firmwareStateMachine : true,
-    overrides.client !== undefined ? overrides.client : clientFactory(),
     overrides.sirenParticleId !== undefined ? overrides.sirenParticleId : 'fakeSirenParticleId',
     overrides.sentLowBatteryAlertAt !== undefined ? overrides.sentLowBatteryAlertAt : '2021-03-09T19:37:28.176Z',
+    overrides.createdAt !== undefined ? overrides.createdAt : '2021-05-05T19:37:28.176Z',
+    overrides.updatedAt !== undefined ? overrides.updatedAt : '2021-06-07T03:19:30.832Z',
+    overrides.client !== undefined ? overrides.client : clientFactory(),
   )
 }
 


### PR DESCRIPTION
## Test Plan

- :heavy_check_mark: Add a new client with leading, trailing, and internal whitespace for all values where this is possible through the UI. See that
   - :heavy_check_mark: client is added in DB without the leading and trailing whitespace
- :heavy_check_mark: Try to add a new client with only whitespace for each value individually for all values where this is possible through the UI. See that
   - :heavy_check_mark: client cannot be added if the value was required
   - :heavy_check_mark: uses 'null' when the value was not required
- :heavy_check_mark: Add a new client with an existing `displayName` but with leading and trailing whitespace. See that
   - :heavy_check_mark: client cannot be added
- :heavy_check_mark:  Edit an existing client with leading, trailing, and internal whitespace for all values where this is possible through the UI. See that
   - :heavy_check_mark: client is updated in DB without the leading and trailing whitespace
- :heavy_check_mark: Try to edit an existing client with only whitespace for each value individually for all values where this is possible through the UI. See that
   - :heavy_check_mark: client cannot be updated if the value was required
   - :heavy_check_mark: uses 'null' when the value was not required
- :heavy_check_mark: Edit an existing client with an existing `displayName` but with leading and trailing whitespace. See that
   - :heavy_check_mark: client cannot be updated

- :heavy_check_mark: Add a new location with leading, trailing, and internal whitespace for all values where this is possible through the UI. See that
   - :heavy_check_mark: location is added in DB without the leading and trailing whitespace
- :heavy_check_mark: Try to add a new location
   - :heavy_check_mark: location cannot be added if the value was required
- :heavy_check_mark: Edit an existing location with leading, trailing, and internal whitespace for all values where this is possible through the UI. See that
   - :heavy_check_mark: location is updated in DB without the leading and trailing whitespace
- :heavy_check_mark: Try to edit an existing location with only whitespace for each value individually for all values where this is possible through the UI. See that
   - :heavy_check_mark: location cannot be updated if the value was required
- :heavy_check_mark: `created_at` and `updated_at` behave as expected when locations are added or updated
   
Note that I'm not bothering to test the values that do not pass the UI validation (for example `responderPhoneNumber`). The trimming should be enforced at the API level, but I don't anticipate us trying to hack our own system by using the API instead of the UI (or the DB directly).