### PR TITLE
Remove `/api/devicevitals` and everything everything that is only used in Sensors v3.0 (INS + SSM)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ the code was deployed.
 ### Removed
 
 - Unused device health endpoint (api/devicevitals).
+- Unused INS radar data endpoint (api/innosent).
+- `radar_type` column in `locations` table.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ the code was deployed.
 
 - Added missing rows to the `clients` table and started using them.
 
+### Removed
+
+- Unused device health endpoint (api/devicevitals).
+
 ### Security
 
 - Updated dependencies.

--- a/server/Location.js
+++ b/server/Location.js
@@ -8,7 +8,6 @@ class Location {
     sentVitalsAlertAt,
     doorCoreId,
     radarCoreId,
-    radarType,
     twilioNumber,
     initialTimer,
     isActive,
@@ -27,7 +26,6 @@ class Location {
     this.sentVitalsAlertAt = sentVitalsAlertAt
     this.doorCoreId = doorCoreId
     this.radarCoreId = radarCoreId
-    this.radarType = radarType
     this.twilioNumber = twilioNumber
     this.initialTimer = initialTimer
     this.isActive = isActive

--- a/server/RadarTypeEnum.js
+++ b/server/RadarTypeEnum.js
@@ -1,6 +1,0 @@
-const RADAR_TYPE = {
-  XETHRU: 'XeThru',
-  INNOSENT: 'Innosent',
-}
-
-module.exports = Object.freeze(RADAR_TYPE)

--- a/server/dashboard.js
+++ b/server/dashboard.js
@@ -211,13 +211,6 @@ async function renderLocationEditPage(req, res) {
     const clients = await db.getClients()
     const currentLocation = await db.getLocationData(req.params.locationId)
 
-    // for the dropdown in the edit screen so it does not display duplicate options
-    if (currentLocation.radarType === 'XeThru') {
-      currentLocation.otherType = 'Innosent'
-    } else {
-      currentLocation.otherType = 'XeThru'
-    }
-
     const viewParams = {
       currentLocation,
       clients: clients.map(client => {
@@ -420,7 +413,6 @@ const validateNewLocation = Validator.body([
   'displayName',
   'doorCoreID',
   'radarCoreID',
-  'radarType',
   'twilioPhone',
   'firmwareStateMachine',
   'clientId',
@@ -461,7 +453,6 @@ async function submitNewLocation(req, res) {
         data.displayName,
         data.doorCoreID,
         data.radarCoreID,
-        data.radarType,
         data.twilioPhone,
         data.firmwareStateMachine,
         data.clientId,
@@ -483,7 +474,6 @@ const validateEditLocation = Validator.body([
   'displayName',
   'doorCoreID',
   'radarCoreID',
-  'radarType',
   'twilioPhone',
   'movementThreshold',
   'durationTimer',
@@ -521,7 +511,6 @@ async function submitEditLocation(req, res) {
         data.displayName,
         data.doorCoreID,
         data.radarCoreID,
-        data.radarType,
         data.twilioPhone,
         data.movementThreshold,
         data.durationTimer,

--- a/server/db/029-drop-location-radartype.sql
+++ b/server/db/029-drop-location-radartype.sql
@@ -1,0 +1,22 @@
+DO $migration$
+    DECLARE migrationId INT;
+    DECLARE lastSuccessfulMigrationId INT;
+BEGIN
+    -- The migration ID of this file
+    migrationId := 29;
+
+    -- Get the migration ID of the last file to be successfully run
+    SELECT MAX(id) INTO lastSuccessfulMigrationId
+    FROM migrations;
+
+    -- Only execute this script if its migration ID is next after the last successful migration ID
+    IF migrationId - lastSuccessfulMigrationId = 1 THEN
+        -- ADD SCRIPT HERE
+        ALTER TABLE locations
+        DROP COLUMN radar_type;
+
+        -- Update the migration ID of the last file to be successfully run to the migration ID of this file
+        INSERT INTO migrations (id)
+        VALUES (migrationId);
+    END IF;
+END $migration$;

--- a/server/db/InnosentData.js
+++ b/server/db/InnosentData.js
@@ -1,9 +1,0 @@
-class InnosentData {
-  constructor(streamEntry) {
-    this.timestamp = streamEntry[0].split('-')[0] // get timestamp in millis from redis ID
-    this.inPhase = Number(streamEntry[1][1])
-    this.quadrature = Number(streamEntry[1][3])
-  }
-}
-
-module.exports = InnosentData

--- a/server/db/redis.js
+++ b/server/db/redis.js
@@ -112,10 +112,6 @@ async function addIM21DoorSensorData(locationid, doorSignal, control) {
   }
 }
 
-async function addVitals(locationid, signalStrength, cloudDisconnects) {
-  client.xadd(`vitals:${locationid}`, 'MAXLEN', '~', '10000', '*', 'strength', signalStrength, 'cloudDisc', cloudDisconnects)
-}
-
 // ignore comments included to allow arguments to be split across lines in pairs
 // prettier-ignore
 /* eslint-disable function-call-argument-newline */
@@ -216,7 +212,6 @@ module.exports = {
   addEdgeDeviceHeartbeat,
   addIM21DoorSensorData,
   addInnosentRadarSensorData,
-  addVitals,
   addStateMachineData,
   addXeThruSensorData,
   clearKeys,

--- a/server/mustache-templates/newLocation.mst
+++ b/server/mustache-templates/newLocation.mst
@@ -57,15 +57,6 @@
                     </div>
                 </div>
                 <div class="form-group row justify-content-start row-no-gutters">
-                    <label for="radarType" class="col-sm-3 col-form-label">Radar Type:</label>
-                    <div class="col-sm-5">
-                        <select class="form-control" name="radarType" required>
-                            <option value="XeThru">XeThru</option>
-                            <option value="Innosent">Innosent</option>
-                        </select>
-                    </div>
-                </div>
-                <div class="form-group row justify-content-start row-no-gutters">
                     <label for="twilioPhone" class="col-sm-3 col-form-label">Twilio Phone Number:</label>
                     <div class="col-sm-5">
                         <input type="text" class="form-control" name="twilioPhone" value="+1" required pattern="[+][1]\d{10}">

--- a/server/mustache-templates/updateLocation.mst
+++ b/server/mustache-templates/updateLocation.mst
@@ -56,15 +56,6 @@
                     </div>
                 </div>
                 <div class="form-group row justify-content-start row-no-gutters">
-                    <label for="radarType" class="col-sm-3 col-form-label">Radar Type:</label>
-                    <div class="col-sm-5">
-                        <select class="form-control" name="radarType" required>
-                            <option selected value="{{radarType}}">{{radarType}}</option>
-                            <option value="{{otherType}}">{{otherType}}</option>
-                        </select>
-                    </div>
-                </div>
-                <div class="form-group row justify-content-start row-no-gutters">
                     <label for="twilioPhone" class="col-sm-3 col-form-label">Twilio Phone Number:</label>
                     <div class="col-sm-5">
                         <input type="text" class="form-control" name="twilioPhone" value="{{twilioNumber}}" required pattern="[+][1]\d{10}">

--- a/server/routes.js
+++ b/server/routes.js
@@ -21,7 +21,6 @@ function configureRoutes(app) {
   app.post('/locations/:locationId', dashboard.validateEditLocation, dashboard.submitEditLocation)
   app.post('/login', dashboard.submitLogin)
 
-  app.post('/api/devicevitals', vitals.validateDeviceVitals, vitals.handleDeviceVitals)
   app.post('/api/heartbeat', vitals.validateHeartbeat, vitals.handleHeartbeat)
   app.post('/api/sirenAddressed', siren.validateSirenAddressed, siren.handleSirenAddressed)
   app.post('/api/sirenEscalated', siren.validateSirenEscalated, siren.handleSirenEscalated)

--- a/server/setup_postgresql.sh
+++ b/server/setup_postgresql.sh
@@ -27,3 +27,4 @@ sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DAT
 sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE --set=sslmode=require -f ./db/026-add-sent-vitals-alert-at.sql
 sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE --set=sslmode=require -f ./db/027-add-location-created-and-updated-dates.sql
 sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE --set=sslmode=require -f ./db/028-refactor-clients.sql
+sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE --set=sslmode=require -f ./db/029-drop-location-radartype.sql

--- a/server/smokeTest.js
+++ b/server/smokeTest.js
@@ -4,7 +4,6 @@ const axios = require('axios').default
 // In-house dependencies
 const { helpers } = require('brave-alert-lib')
 const { getRandomArbitrary, getRandomInt } = require('./testingHelpers')
-const RADAR_TYPE = require('./RadarTypeEnum')
 const XETHRU_STATE = require('./SessionStateXethruEnum')
 const SENSOR_EVENT = require('./SensorEventEnum')
 const im21door = require('./im21door')
@@ -29,12 +28,12 @@ async function teardown() {
   }
 }
 
-async function setup(recipientPhoneNumber, twilioPhoneNumber, type) {
+async function setup(recipientPhoneNumber, twilioPhoneNumber, firmwareStateMachine) {
   try {
     await axios.post('/smokeTest/setup', {
       recipientNumber: recipientPhoneNumber,
       twilioNumber: twilioPhoneNumber,
-      radarType: type,
+      firmwareStateMachine,
     })
   } catch (e) {
     helpers.log(e)
@@ -103,7 +102,7 @@ async function smokeTest(recipientPhoneNumber, twilioPhoneNumber) {
   try {
     helpers.log('Running XeThru Server-side State Machine Smoke Tests')
     await teardown()
-    await setup(recipientPhoneNumber, twilioPhoneNumber, RADAR_TYPE.XETHRU)
+    await setup(recipientPhoneNumber, twilioPhoneNumber, false)
     for (let i = 0; i < 15; i += 1) {
       await xeThruMovement(radar_coreID, getRandomInt(MOV_THRESHOLD + 1, 100), getRandomInt(MOV_THRESHOLD + 1, 100))
     }
@@ -130,7 +129,7 @@ async function smokeTest(recipientPhoneNumber, twilioPhoneNumber) {
   try {
     helpers.log('Running INS Firmware State Machine Smoke Tests')
     await teardown()
-    await setup(recipientPhoneNumber, twilioPhoneNumber, RADAR_TYPE.INNOSENT)
+    await setup(recipientPhoneNumber, twilioPhoneNumber, true)
     await stillnessEvent(radar_coreID)
     await helpers.sleep(70000)
   } catch (error) {

--- a/server/stateMachine/StateMachine.js
+++ b/server/stateMachine/StateMachine.js
@@ -15,11 +15,7 @@ async function getNextState(location, handleAlert) {
     } else {
       state = stateData.state
     }
-    const movementOverThreshold = await stateMachineHelpers.movementAverageOverThreshold(
-      location.radarType,
-      location.locationid,
-      location.movementThreshold,
-    )
+    const movementOverThreshold = await stateMachineHelpers.movementAverageOverThreshold(location.locationid, location.movementThreshold)
 
     switch (state) {
       case STATE.IDLE:

--- a/server/stateMachine/stateMachineHelpers.js
+++ b/server/stateMachine/stateMachineHelpers.js
@@ -1,51 +1,30 @@
 const { helpers } = require('brave-alert-lib')
 const redis = require('../db/redis')
-const RADAR_TYPE = require('../RadarTypeEnum')
 
-async function movementAverageOverThreshold(radarType, locationid, movementThreshold) {
+async function movementAverageOverThreshold(locationid, movementThreshold) {
   const windowSize = helpers.getEnvVar('RADAR_WINDOW_SIZE_SECONDS')
-  if (radarType === RADAR_TYPE.XETHRU) {
-    try {
-      const xethruHistory = await redis.getXethruTimeWindow(locationid, windowSize)
-      // xethruHistory will only have length 0 if there has been no radar data received in the last windowSize seconds
-      if (xethruHistory.length === 0) {
-        return false
-      }
-      const mov_f_avg =
-        xethruHistory
-          .map(entry => {
-            return entry.mov_f
-          })
-          .reduce((a, b) => a + b) / xethruHistory.length
-      const mov_s_avg =
-        xethruHistory
-          .map(entry => {
-            return entry.mov_s
-          })
-          .reduce((a, b) => a + b) / xethruHistory.length
-      return mov_f_avg > movementThreshold || mov_s_avg > movementThreshold
-    } catch (error) {
-      helpers.logError(`Error computing XeThru Moving Average: ${error}`)
+  try {
+    const xethruHistory = await redis.getXethruTimeWindow(locationid, windowSize)
+    // xethruHistory will only have length 0 if there has been no radar data received in the last windowSize seconds
+    if (xethruHistory.length === 0) {
       return false
     }
-  } else if (radarType === RADAR_TYPE.INNOSENT) {
-    try {
-      const innosentHistory = await redis.getInnosentTimeWindow(locationid, windowSize)
-      // innosentHistory will only have length 0 if there has been no radar data received in the last windowSize seconds
-      if (innosentHistory.length === 0) {
-        return false
-      }
-      const inPhase_avg =
-        innosentHistory
-          .map(entry => {
-            return Math.abs(entry.inPhase)
-          })
-          .reduce((a, b) => a + b) / innosentHistory.length
-      return inPhase_avg > movementThreshold
-    } catch (error) {
-      helpers.logError(`Error computing Innosent Moving Average: ${error}`)
-      return false
-    }
+    const mov_f_avg =
+      xethruHistory
+        .map(entry => {
+          return entry.mov_f
+        })
+        .reduce((a, b) => a + b) / xethruHistory.length
+    const mov_s_avg =
+      xethruHistory
+        .map(entry => {
+          return entry.mov_s
+        })
+        .reduce((a, b) => a + b) / xethruHistory.length
+    return mov_f_avg > movementThreshold || mov_s_avg > movementThreshold
+  } catch (error) {
+    helpers.logError(`Error computing XeThru Moving Average: ${error}`)
+    return false
   }
 }
 

--- a/server/test/integration/dashboardTest/submitEditLocationTest.js
+++ b/server/test/integration/dashboardTest/submitEditLocationTest.js
@@ -55,7 +55,6 @@ describe('dashboard.js integration tests: submitEditLocation', () => {
         displayName: 'New Name',
         doorCoreID: 'new_door_core',
         radarCoreID: 'new_radar_core',
-        radarType: 'Innosent',
         responderPhoneNumber: '+12223334567',
         twilioPhone: '+11112223456',
         movementThreshold: 15,
@@ -81,7 +80,6 @@ describe('dashboard.js integration tests: submitEditLocation', () => {
       expect(updatedLocation.displayName).to.equal(this.goodRequest.displayName)
       expect(updatedLocation.doorCoreId).to.equal(this.goodRequest.doorCoreID)
       expect(updatedLocation.radarCoreId).to.equal(this.goodRequest.radarCoreID)
-      expect(updatedLocation.radarType).to.equal(this.goodRequest.radarType)
       expect(updatedLocation.twilioNumber).to.equal(this.goodRequest.twilioPhone)
       expect(updatedLocation.isActive).to.be.true
       expect(updatedLocation.firmwareStateMachine).to.be.false
@@ -105,7 +103,6 @@ describe('dashboard.js integration tests: submitEditLocation', () => {
         displayName: ' New Name ',
         doorCoreID: '  new_door_core  ',
         radarCoreID: '   new_radar_core ',
-        radarType: '   Innosent   ',
         responderPhoneNumber: ' +12223334567   ',
         twilioPhone: '    +11112223456    ',
         movementThreshold: '    15    ',
@@ -131,7 +128,6 @@ describe('dashboard.js integration tests: submitEditLocation', () => {
       expect(updatedLocation.displayName).to.equal(this.goodRequest.displayName.trim())
       expect(updatedLocation.doorCoreId).to.equal(this.goodRequest.doorCoreID.trim())
       expect(updatedLocation.radarCoreId).to.equal(this.goodRequest.radarCoreID.trim())
-      expect(updatedLocation.radarType).to.equal(this.goodRequest.radarType.trim())
       expect(updatedLocation.twilioNumber).to.equal(this.goodRequest.twilioPhone.trim())
       expect(updatedLocation.isActive).to.be.true
       expect(updatedLocation.firmwareStateMachine).to.be.false
@@ -155,7 +151,6 @@ describe('dashboard.js integration tests: submitEditLocation', () => {
         displayName: 'New Name',
         doorCoreID: 'new_door_core',
         radarCoreID: 'new_radar_core',
-        radarType: 'Innosent',
         responderPhoneNumber: '+12223334567',
         twilioPhone: '+11112223456',
         movementThreshold: 15,
@@ -181,7 +176,6 @@ describe('dashboard.js integration tests: submitEditLocation', () => {
       expect(updatedLocation.displayName).to.equal(this.goodRequest.displayName)
       expect(updatedLocation.doorCoreId).to.equal(this.goodRequest.doorCoreID)
       expect(updatedLocation.radarCoreId).to.equal(this.goodRequest.radarCoreID)
-      expect(updatedLocation.radarType).to.equal(this.goodRequest.radarType)
       expect(updatedLocation.twilioNumber).to.equal(this.goodRequest.twilioPhone)
       expect(updatedLocation.isActive).to.be.false
       expect(updatedLocation.firmwareStateMachine).to.be.false
@@ -206,7 +200,6 @@ describe('dashboard.js integration tests: submitEditLocation', () => {
         displayName: 'New Name',
         doorCoreID: 'new_door_core',
         radarCoreID: 'new_radar_core',
-        radarType: 'Innosent',
         responderPhoneNumber: '+12223334567',
         twilioPhone: '+11112223456',
         movementThreshold: 15,
@@ -249,7 +242,6 @@ describe('dashboard.js integration tests: submitEditLocation', () => {
         displayName: '',
         doorCoreID: '',
         radarCoreID: '',
-        radarType: '',
         responderPhoneNumber: '',
         twilioPhone: '',
         movementThreshold: '',
@@ -274,7 +266,7 @@ describe('dashboard.js integration tests: submitEditLocation', () => {
 
     it('should log the error', () => {
       expect(helpers.log).to.have.been.calledWith(
-        `Bad request to /locations/test1: displayName (Invalid value),doorCoreID (Invalid value),radarCoreID (Invalid value),radarType (Invalid value),twilioPhone (Invalid value),movementThreshold (Invalid value),durationTimer (Invalid value),stillnessTimer (Invalid value),initialTimer (Invalid value),isActive (Invalid value),firmwareStateMachine (Invalid value),clientId (Invalid value)`,
+        `Bad request to /locations/test1: displayName (Invalid value),doorCoreID (Invalid value),radarCoreID (Invalid value),twilioPhone (Invalid value),movementThreshold (Invalid value),durationTimer (Invalid value),stillnessTimer (Invalid value),initialTimer (Invalid value),isActive (Invalid value),firmwareStateMachine (Invalid value),clientId (Invalid value)`,
       )
     })
   })
@@ -306,7 +298,7 @@ describe('dashboard.js integration tests: submitEditLocation', () => {
 
     it('should log the error', () => {
       expect(helpers.log).to.have.been.calledWith(
-        `Bad request to /locations/test1: displayName (Invalid value),doorCoreID (Invalid value),radarCoreID (Invalid value),radarType (Invalid value),twilioPhone (Invalid value),movementThreshold (Invalid value),durationTimer (Invalid value),stillnessTimer (Invalid value),initialTimer (Invalid value),isActive (Invalid value),firmwareStateMachine (Invalid value),clientId (Invalid value)`,
+        `Bad request to /locations/test1: displayName (Invalid value),doorCoreID (Invalid value),radarCoreID (Invalid value),twilioPhone (Invalid value),movementThreshold (Invalid value),durationTimer (Invalid value),stillnessTimer (Invalid value),initialTimer (Invalid value),isActive (Invalid value),firmwareStateMachine (Invalid value),clientId (Invalid value)`,
       )
     })
   })

--- a/server/test/integration/dashboardTest/submitNewLocationTest.js
+++ b/server/test/integration/dashboardTest/submitNewLocationTest.js
@@ -48,7 +48,6 @@ describe('dashboard.js integration tests: submitNewLocation', () => {
       this.displayName = 'locationName'
       this.doorCoreId = 'door_coreID'
       this.radarCoreId = 'radar_coreID'
-      this.radarType = 'XeThru'
       this.twilioNumber = '+15005550006'
       this.firmwareStateMachine = false
       const goodRequest = {
@@ -56,7 +55,6 @@ describe('dashboard.js integration tests: submitNewLocation', () => {
         displayName: this.displayName,
         doorCoreID: this.doorCoreId,
         radarCoreID: this.radarCoreId,
-        radarType: this.radarType,
         twilioPhone: this.twilioNumber,
         firmwareStateMachine: this.firmwareStateMachine.toString(),
         clientId: this.client.id,
@@ -77,7 +75,6 @@ describe('dashboard.js integration tests: submitNewLocation', () => {
         displayName: newLocation.displayName,
         doorCoreId: newLocation.doorCoreId,
         radarCoreId: newLocation.radarCoreId,
-        radarType: newLocation.radarType,
         twilioNumber: newLocation.twilioNumber,
         firmwareStateMachine: newLocation.firmwareStateMachine,
         clientId: newLocation.client.id,
@@ -86,7 +83,6 @@ describe('dashboard.js integration tests: submitNewLocation', () => {
         displayName: this.displayName,
         doorCoreId: this.doorCoreId,
         radarCoreId: this.radarCoreId,
-        radarType: this.radarType,
         twilioNumber: this.twilioNumber,
         firmwareStateMachine: this.firmwareStateMachine,
         clientId: this.client.id,
@@ -105,7 +101,6 @@ describe('dashboard.js integration tests: submitNewLocation', () => {
       this.displayName = '  locationName  '
       this.doorCoreId = '   door_coreID   '
       this.radarCoreId = '    radar_coreID    '
-      this.radarType = '  XeThru  '
       this.twilioNumber = '   +15005550006    '
       this.firmwareStateMachine = false
       const goodRequest = {
@@ -113,7 +108,6 @@ describe('dashboard.js integration tests: submitNewLocation', () => {
         displayName: this.displayName,
         doorCoreID: this.doorCoreId,
         radarCoreID: this.radarCoreId,
-        radarType: this.radarType,
         twilioPhone: this.twilioNumber,
         firmwareStateMachine: `  ${this.firmwareStateMachine.toString()} `,
         clientId: `  ${this.client.id}   `,
@@ -134,7 +128,6 @@ describe('dashboard.js integration tests: submitNewLocation', () => {
         displayName: newLocation.displayName,
         doorCoreId: newLocation.doorCoreId,
         radarCoreId: newLocation.radarCoreId,
-        radarType: newLocation.radarType,
         twilioNumber: newLocation.twilioNumber,
         firmwareStateMachine: newLocation.firmwareStateMachine,
         clientId: newLocation.client.id,
@@ -143,7 +136,6 @@ describe('dashboard.js integration tests: submitNewLocation', () => {
         displayName: this.displayName.trim(),
         doorCoreId: this.doorCoreId.trim(),
         radarCoreId: this.radarCoreId.trim(),
-        radarType: this.radarType.trim(),
         twilioNumber: this.twilioNumber.trim(),
         firmwareStateMachine: this.firmwareStateMachine,
         clientId: this.client.id.trim(),
@@ -166,7 +158,6 @@ describe('dashboard.js integration tests: submitNewLocation', () => {
         displayName: 'locationName',
         doorCoreID: 'door_coreID',
         radarCoreID: 'radar_coreID',
-        radarType: 'XeThru',
         twilioPhone: '+15005550006',
         firmwareStateMachine: 'false',
         clientId: this.clientId,
@@ -197,7 +188,6 @@ describe('dashboard.js integration tests: submitNewLocation', () => {
         displayName: 'locationName',
         doorCoreID: 'door_coreID',
         radarCoreID: 'radar_coreID',
-        radarType: 'XeThru',
         twilioPhone: '+15005550006',
         firmwareStateMachine: 'false',
         clientId: '91ddc8f7-c2e7-490e-bfe9-3d2880a76108',
@@ -233,7 +223,6 @@ describe('dashboard.js integration tests: submitNewLocation', () => {
         displayName: '',
         doorCoreID: '',
         radarCoreID: '',
-        radarType: '',
         twilioPhone: '',
         firmwareStateMachine: '',
         clientId: '',
@@ -252,7 +241,7 @@ describe('dashboard.js integration tests: submitNewLocation', () => {
 
     it('should log the error', () => {
       expect(helpers.log).to.have.been.calledWith(
-        `Bad request to /locations: locationid (Invalid value),displayName (Invalid value),doorCoreID (Invalid value),radarCoreID (Invalid value),radarType (Invalid value),twilioPhone (Invalid value),firmwareStateMachine (Invalid value),clientId (Invalid value)`,
+        `Bad request to /locations: locationid (Invalid value),displayName (Invalid value),doorCoreID (Invalid value),radarCoreID (Invalid value),twilioPhone (Invalid value),firmwareStateMachine (Invalid value),clientId (Invalid value)`,
       )
     })
   })
@@ -279,7 +268,7 @@ describe('dashboard.js integration tests: submitNewLocation', () => {
 
     it('should log the error', () => {
       expect(helpers.log).to.have.been.calledWith(
-        `Bad request to /locations: locationid (Invalid value),displayName (Invalid value),doorCoreID (Invalid value),radarCoreID (Invalid value),radarType (Invalid value),twilioPhone (Invalid value),firmwareStateMachine (Invalid value),clientId (Invalid value)`,
+        `Bad request to /locations: locationid (Invalid value),displayName (Invalid value),doorCoreID (Invalid value),radarCoreID (Invalid value),twilioPhone (Invalid value),firmwareStateMachine (Invalid value),clientId (Invalid value)`,
       )
     })
   })
@@ -304,7 +293,6 @@ describe('dashboard.js integration tests: submitNewLocation', () => {
         displayName: 'locationName',
         doorCoreID: 'door_coreID',
         radarCoreID: 'radar_coreID',
-        radarType: 'XeThru',
         twilioPhone: '+15005550006',
         firmwareStateMachine: 'false',
         clientId: this.client.id,

--- a/server/test/integration/serverTest.js
+++ b/server/test/integration/serverTest.js
@@ -398,14 +398,6 @@ describe('Brave Sensor server', () => {
       expect(response).to.have.status(200)
     })
 
-    it('should return 400 to a device vitals signal with an unregistered coreID', async () => {
-      const response = await chai
-        .request(server)
-        .post('/api/devicevitals')
-        .send({ coreid: 'unregisteredID', data: { data: 'closed', control: 'AA' } })
-      expect(response).to.have.status(400)
-    })
-
     it('should call sendSingleAlert if door sends low battery signal', async () => {
       await im21Door(door_coreID, im21door.createOpenLowBatterySignal())
       expect(braveAlerter.sendSingleAlert).to.be.called
@@ -505,14 +497,6 @@ describe('Brave Sensor server', () => {
       expect(response).to.have.status(200)
     })
 
-    it('should return 400 to a device vitals signal with an unregistered coreID', async () => {
-      const response = await chai
-        .request(server)
-        .post('/api/devicevitals')
-        .send({ coreid: 'unregisteredID', data: { data: 'closed', control: 'AA' } })
-      expect(response).to.have.status(400)
-    })
-
     it('radar data with no movement should be saved to redis, but should not trigger a session', async () => {
       for (let i = 0; i < 5; i += 1) {
         await xeThruSilence(radar_coreID)
@@ -560,14 +544,6 @@ describe('Brave Sensor server', () => {
         .post('/api/door')
         .send({ coreid: 'unregisteredID', data: { data: 'closed', control: 'AA' } })
       expect(response).to.have.status(200)
-    })
-
-    it('should return 400 to a device vitals signal with an unregistered coreID', async () => {
-      const response = await chai
-        .request(server)
-        .post('/api/devicevitals')
-        .send({ coreid: 'unregisteredID', data: { data: 'closed', control: 'AA' } })
-      expect(response).to.have.status(400)
     })
 
     it('radar data with no movement should be saved to redis, but should not trigger a session', async () => {
@@ -618,14 +594,6 @@ describe('Brave Sensor server', () => {
         .post('/api/door')
         .send({ coreid: 'unregisteredID', data: { data: 'closed', control: 'AA' } })
       expect(response).to.have.status(200)
-    })
-
-    it('should return 400 to a device vitals signal with an unregistered coreID', async () => {
-      const response = await chai
-        .request(server)
-        .post('/api/devicevitals')
-        .send({ coreid: 'unregisteredID', data: { data: 'closed', control: 'AA' } })
-      expect(response).to.have.status(400)
     })
 
     it('radar data with no movement should be saved to redis, but should not trigger a session', async () => {
@@ -715,14 +683,6 @@ describe('Brave Sensor server', () => {
       expect(response).to.have.status(200)
     })
 
-    it('should return 400 to a device vitals signal with an unregistered coreID', async () => {
-      const response = await chai
-        .request(server)
-        .post('/api/devicevitals')
-        .send({ coreid: 'unregisteredID', data: { data: 'closed', control: 'AA' } })
-      expect(response).to.have.status(400)
-    })
-
     it('radar data with no movement should be saved to redis, but should not trigger a session', async () => {
       for (let i = 0; i < 5; i += 1) {
         await innosentSilence(radar_coreID)
@@ -785,78 +745,6 @@ describe('Brave Sensor server', () => {
 
         const response = await chai.request(server).post('/api/door').send(badRequest)
         expect(response).to.have.status(200)
-      })
-    })
-
-    describe('api/devicevitals endpoint', () => {
-      beforeEach(async () => {
-        const client = await factories.clientDBFactory(db, { responderPhoneNumber: testLocation1PhoneNumber })
-        await locationDBFactory(db, {
-          locationid: testLocation1Id,
-          doorCoreId: door_coreID,
-          radarType: RADAR_TYPE.XETHRU,
-          firmwareStateMachine: false,
-          clientId: client.id,
-        })
-        await im21Door(door_coreID, im21door.createClosedSignal())
-      })
-
-      it('should return 200 for a valid request', async () => {
-        const goodRequest = {
-          coreid: door_coreID,
-          data: `{"device":{"network":{"signal":{"at":"Wi-Fi","strength":100,"strength_units":"%","strengthv":-47,"strengthv_units":"dBm","strengthv_type":"RSSI","quality":100,"quality_units":"%","qualityv":43,"qualityv_units":"dB","qualityv_type":"SNR"}},"cloud":{"connection":{"status":"connected","error":17,"attempts":1,"disconnects":9,"disconnect_reason":"error"},"coap":{"transmit":1305228,"retransmit":1721,"unack":0,"round_trip":1001},"publish":{"rate_limited":0}},"system":{"uptime":1298620,"memory":{"used":95000,"total":160488}}},"service":{"device":{"status":"ok"},"cloud":{"uptime":94305,"publish":{"sent":93201}},"coap":{"round_trip":1327}}}`,
-        }
-
-        const response = await chai.request(server).post('/api/devicevitals').send(goodRequest)
-        expect(response).to.have.status(200)
-      })
-
-      it('should return 400 for a request that does not contain coreid', async () => {
-        const badRequest = {
-          data: `{"device":{"network":{"signal":{"at":"Wi-Fi","strength":100,"strength_units":"%","strengthv":-47,"strengthv_units":"dBm","strengthv_type":"RSSI","quality":100,"quality_units":"%","qualityv":43,"qualityv_units":"dB","qualityv_type":"SNR"}},"cloud":{"connection":{"status":"connected","error":17,"attempts":1,"disconnects":9,"disconnect_reason":"error"},"coap":{"transmit":1305228,"retransmit":1721,"unack":0,"round_trip":1001},"publish":{"rate_limited":0}},"system":{"uptime":1298620,"memory":{"used":95000,"total":160488}}},"service":{"device":{"status":"ok"},"cloud":{"uptime":94305,"publish":{"sent":93201}},"coap":{"round_trip":1327}}}`,
-        }
-
-        const response = await chai.request(server).post('/api/devicevitals').send(badRequest)
-        expect(response).to.have.status(400)
-      })
-
-      it('should return 400 for a request that does not contain data', async () => {
-        const badRequest = {
-          coreid: door_coreID,
-        }
-
-        const response = await chai.request(server).post('/api/devicevitals').send(badRequest)
-        expect(response).to.have.status(400)
-      })
-
-      it('should return 400 for a request that contains a valid coreid and a totally invalid data field', async () => {
-        const badRequest = {
-          coreid: door_coreID,
-          data: `{"uselessField":"useless"}`,
-        }
-
-        const response = await chai.request(server).post('/api/devicevitals').send(badRequest)
-        expect(response).to.have.status(400)
-      })
-
-      it('should return 400 for a request that contains a valid coreid and an invalid data field missing signal strength', async () => {
-        const badRequest = {
-          coreid: door_coreID,
-          data: `{"device":{"network":{"signal":{"at":"Wi-Fi","strength_units":"%","strengthv":-47,"strengthv_units":"dBm","strengthv_type":"RSSI","quality":100,"quality_units":"%","qualityv":43,"qualityv_units":"dB","qualityv_type":"SNR"}},"cloud":{"connection":{"status":"connected","error":17,"attempts":1,"disconnects":9,"disconnect_reason":"error"},"coap":{"transmit":1305228,"retransmit":1721,"unack":0,"round_trip":1001},"publish":{"rate_limited":0}},"system":{"uptime":1298620,"memory":{"used":95000,"total":160488}}},"service":{"device":{"status":"ok"},"cloud":{"uptime":94305,"publish":{"sent":93201}},"coap":{"round_trip":1327}}}`,
-        }
-
-        const response = await chai.request(server).post('/api/devicevitals').send(badRequest)
-        expect(response).to.have.status(400)
-      })
-
-      it('should return 400 for a request that contains a valid coreid and an invalid data field missing device disconnects', async () => {
-        const badRequest = {
-          coreid: door_coreID,
-          data: `{{"device":{"network":{"signal":{"at":"Wi-Fi","strength":100,"strength_units":"%","strengthv":-47,"strengthv_units":"dBm","strengthv_type":"RSSI","quality":100,"quality_units":"%","qualityv":43,"qualityv_units":"dB","qualityv_type":"SNR"}},"cloud":{"connection":{"status":"connected","error":17,"attempts":1,"disconnect_reason":"error"},"coap":{"transmit":1305228,"retransmit":1721,"unack":0,"round_trip":1001},"publish":{"rate_limited":0}},"system":{"uptime":1298620,"memory":{"used":95000,"total":160488}}},"service":{"device":{"status":"ok"},"cloud":{"uptime":94305,"publish":{"sent":93201}},"coap":{"round_trip":1327}}}`,
-        }
-
-        const response = await chai.request(server).post('/api/devicevitals').send(badRequest)
-        expect(response).to.have.status(400)
       })
     })
   })

--- a/server/test/unit/StateMachineHelpersTest.js
+++ b/server/test/unit/StateMachineHelpersTest.js
@@ -6,8 +6,7 @@ const redis = require('../../db/redis')
 
 const testLocationId = 'TestLocation1'
 
-const { randomXethruStream, randomInnosentStream } = require('../../testingHelpers')
-const RADAR_TYPE = require('../../RadarTypeEnum')
+const { randomXethruStream } = require('../../testingHelpers')
 const STATE = require('../../stateMachine/SessionStateEnum')
 const stateMachineHelpers = require('../../stateMachine/stateMachineHelpers')
 
@@ -22,78 +21,42 @@ describe('StateMachineHelpers.js unit tests', async () => {
     describe('when RadarType is XeThru', async () => {
       it('should query redis for XeThru values', async () => {
         sandbox.stub(redis, 'getXethruTimeWindow').returns([{ mov_f: 10, mov_s: 10 }])
-        await stateMachineHelpers.movementAverageOverThreshold(RADAR_TYPE.XETHRU, testLocationId, 10)
+        await stateMachineHelpers.movementAverageOverThreshold(testLocationId, 10)
         expect(redis.getXethruTimeWindow).to.be.called
-      })
-
-      it('should not query redis for Innosent values', async () => {
-        sandbox.stub(redis, 'getInnosentTimeWindow')
-        await stateMachineHelpers.movementAverageOverThreshold(RADAR_TYPE.XETHRU, testLocationId, 10)
-        expect(redis.getInnosentTimeWindow).to.be.not.called
       })
 
       it('should return true if both movement fast or slow are above the threshold', async () => {
         sandbox.stub(redis, 'getXethruTimeWindow').returns(randomXethruStream(11, 20, 11, 20, 15))
-        const result = await stateMachineHelpers.movementAverageOverThreshold(RADAR_TYPE.XETHRU, testLocationId, 10)
+        const result = await stateMachineHelpers.movementAverageOverThreshold(testLocationId, 10)
         expect(result).to.be.true
       })
 
       it('should return true if movement fast is above the threshold but movement slow is below', async () => {
         sandbox.stub(redis, 'getXethruTimeWindow').returns(randomXethruStream(11, 20, 5, 9, 15))
-        const result = await stateMachineHelpers.movementAverageOverThreshold(RADAR_TYPE.XETHRU, testLocationId, 10)
+        const result = await stateMachineHelpers.movementAverageOverThreshold(testLocationId, 10)
         expect(result).to.be.true
       })
 
       it('should return true if movement fast average is below the threshold and movement slow is above', async () => {
         sandbox.stub(redis, 'getXethruTimeWindow').returns(randomXethruStream(5, 9, 11, 20, 15))
-        const result = await stateMachineHelpers.movementAverageOverThreshold(RADAR_TYPE.XETHRU, testLocationId, 10)
+        const result = await stateMachineHelpers.movementAverageOverThreshold(testLocationId, 10)
         expect(result).to.be.true
       })
 
       it('should return false if both movement fast and slow are below the threshold', async () => {
         sandbox.stub(redis, 'getXethruTimeWindow').returns(randomXethruStream(5, 9, 5, 9, 15))
-        const result = await stateMachineHelpers.movementAverageOverThreshold(RADAR_TYPE.XETHRU, testLocationId, 16)
+        const result = await stateMachineHelpers.movementAverageOverThreshold(testLocationId, 16)
         expect(result).to.be.false
       })
 
       it('should return false if there are no radar values', async () => {
         sandbox.stub(redis, 'getXethruTimeWindow').returns([])
-        const result = await stateMachineHelpers.movementAverageOverThreshold(RADAR_TYPE.XETHRU, testLocationId, 16)
-        expect(result).to.be.false
-      })
-    })
-    describe('when RadarType is Innosent', async () => {
-      it('should query redis for Innosent values', async () => {
-        sandbox.stub(redis, 'getInnosentTimeWindow')
-        await stateMachineHelpers.movementAverageOverThreshold(RADAR_TYPE.INNOSENT, testLocationId, 10)
-        expect(redis.getInnosentTimeWindow).to.be.called
-      })
-
-      it('should not query redis for XeThru values', async () => {
-        sandbox.stub(redis, 'getXethruTimeWindow')
-        await stateMachineHelpers.movementAverageOverThreshold(RADAR_TYPE.INNOSENT, testLocationId, 10)
-        expect(redis.getXethruTimeWindow).to.not.be.called
-      })
-
-      it('should return true inPhase Average is above the threshold', async () => {
-        sandbox.stub(redis, 'getInnosentTimeWindow').returns(randomInnosentStream(11, 20, 25))
-        const result = await stateMachineHelpers.movementAverageOverThreshold(RADAR_TYPE.INNOSENT, testLocationId, 10)
-        expect(result).to.be.true
-      })
-
-      it('should return false if inPhase Average is below the threshold', async () => {
-        sandbox.stub(redis, 'getInnosentTimeWindow').returns(randomInnosentStream(5, 9, 25))
-        const result = await stateMachineHelpers.movementAverageOverThreshold(RADAR_TYPE.INNOSENT, testLocationId, 10)
-        expect(result).to.be.false
-      })
-
-      it('should return false if there are no radar values', async () => {
-        sandbox.stub(redis, 'getInnosentTimeWindow').returns([])
-        const result = await stateMachineHelpers.movementAverageOverThreshold(RADAR_TYPE.INNOSENT, testLocationId, 10)
+        const result = await stateMachineHelpers.movementAverageOverThreshold(testLocationId, 16)
         expect(result).to.be.false
       })
     })
   })
+
   describe('timerExceeded', async () => {
     it('should return false if the state parameter is present in the result of the getStates query', async () => {
       sandbox.stub(redis, 'getCurrentTimeinMilliseconds')

--- a/server/test/unit/vitalsTest/checkHeartbeatTest.js
+++ b/server/test/unit/vitalsTest/checkHeartbeatTest.js
@@ -9,7 +9,6 @@ const rewire = require('rewire')
 const { helpers } = require('brave-alert-lib')
 const db = require('../../../db/db')
 const redis = require('../../../db/redis')
-const RADAR_TYPE = require('../../../RadarTypeEnum')
 const { locationFactory } = require('../../../testingHelpers')
 
 const vitals = rewire('../../../vitals')
@@ -59,15 +58,13 @@ describe('vitals.js unit tests: checkHeartbeat', () => {
     sandbox.restore()
   })
 
-  describe('when a XeThru device with a server-side state machine and no existing alerts notices that the latest radar message was longer than the threshold', () => {
+  describe('when a device with a server-side state machine and no existing alerts notices that the latest radar message was longer than the threshold', () => {
     beforeEach(async () => {
-      this.testLocation = locationFactory({ firmwareStateMachine: false, isActive: true, radarType: RADAR_TYPE.XETHRU, sentVitalsAlertAt: null })
+      this.testLocation = locationFactory({ firmwareStateMachine: false, isActive: true, sentVitalsAlertAt: null })
       sandbox.stub(db, 'getActiveServerStateMachineLocations').returns([this.testLocation])
       sandbox.stub(db, 'getActiveFirmwareStateMachineLocations').returns([])
 
       sandbox.stub(redis, 'getLatestXeThruSensorData').returns({ timestamp: excessiveRadarTimestamp })
-
-      sandbox.stub(redis, 'getLatestInnosentSensorData').throws('should not have called redis.getLatestInnosentSensorData')
 
       sandbox.stub(redis, 'getLatestDoorSensorData').returns({ timestamp: notExcessiveDoorTimestamp })
 
@@ -101,15 +98,13 @@ describe('vitals.js unit tests: checkHeartbeat', () => {
     })
   })
 
-  describe('when a XeThru device with a server-side state machine and no existing alerts notices that the latest door message was longer than the threshold', () => {
+  describe('when a device with a server-side state machine and no existing alerts notices that the latest door message was longer than the threshold', () => {
     beforeEach(async () => {
-      this.testLocation = locationFactory({ firmwareStateMachine: false, isActive: true, radarType: RADAR_TYPE.XETHRU, sentVitalsAlertAt: null })
+      this.testLocation = locationFactory({ firmwareStateMachine: false, isActive: true, sentVitalsAlertAt: null })
       sandbox.stub(db, 'getActiveServerStateMachineLocations').returns([this.testLocation])
       sandbox.stub(db, 'getActiveFirmwareStateMachineLocations').returns([])
 
       sandbox.stub(redis, 'getLatestXeThruSensorData').returns({ timestamp: notExcessiveRadarTimestamp })
-
-      sandbox.stub(redis, 'getLatestInnosentSensorData').throws('should not have called redis.getLatestInnosentSensorData')
 
       sandbox.stub(redis, 'getLatestDoorSensorData').returns({ timestamp: excessiveDoorTimestamp })
 
@@ -143,20 +138,17 @@ describe('vitals.js unit tests: checkHeartbeat', () => {
     })
   })
 
-  describe('when a XeThru device with a server-side state machine and an existing alert is no longer exceeding the door or radar thresholds', () => {
+  describe('when a device with a server-side state machine and an existing alert is no longer exceeding the door or radar thresholds', () => {
     beforeEach(async () => {
       this.testLocation = locationFactory({
         firmwareStateMachine: false,
         isActive: true,
-        radarType: RADAR_TYPE.XETHRU,
         sentVitalsAlertAt: new Date('2020-10-10T10:10:10.000Z'),
       })
       sandbox.stub(db, 'getActiveServerStateMachineLocations').returns([this.testLocation])
       sandbox.stub(db, 'getActiveFirmwareStateMachineLocations').returns([])
 
       sandbox.stub(redis, 'getLatestXeThruSensorData').returns({ timestamp: notExcessiveRadarTimestamp })
-
-      sandbox.stub(redis, 'getLatestInnosentSensorData').throws('should not have called redis.getLatestInnosentSensorData')
 
       sandbox.stub(redis, 'getLatestDoorSensorData').returns({ timestamp: notExcessiveDoorTimestamp })
 
@@ -190,20 +182,17 @@ describe('vitals.js unit tests: checkHeartbeat', () => {
     })
   })
 
-  describe('when a XeThru device with a server-side state machine and an existing alert is still exceeding the door or radar threshold but it has not yet exceeded the subsequent vitals threshold', () => {
+  describe('when a device with a server-side state machine and an existing alert is still exceeding the door or radar threshold but it has not yet exceeded the subsequent vitals threshold', () => {
     beforeEach(async () => {
       this.testLocation = locationFactory({
         firmwareStateMachine: false,
         isActive: true,
-        radarType: RADAR_TYPE.XETHRU,
         sentVitalsAlertAt: new Date(),
       })
       sandbox.stub(db, 'getActiveServerStateMachineLocations').returns([this.testLocation])
       sandbox.stub(db, 'getActiveFirmwareStateMachineLocations').returns([])
 
       sandbox.stub(redis, 'getLatestXeThruSensorData').returns({ timestamp: excessiveRadarTimestamp })
-
-      sandbox.stub(redis, 'getLatestInnosentSensorData').throws('should not have called redis.getLatestInnosentSensorData')
 
       sandbox.stub(redis, 'getLatestDoorSensorData').returns({ timestamp: notExcessiveDoorTimestamp })
 
@@ -237,20 +226,17 @@ describe('vitals.js unit tests: checkHeartbeat', () => {
     })
   })
 
-  describe('when a Xethru device with a server-side state machine and an existing alert is still exceeding the door or radar threshold and has exceeded the subsequent vitals threshold', () => {
+  describe('when a device with a server-side state machine and an existing alert is still exceeding the door or radar threshold and has exceeded the subsequent vitals threshold', () => {
     beforeEach(async () => {
       this.testLocation = locationFactory({
         firmwareStateMachine: false,
         isActive: true,
-        radarType: RADAR_TYPE.XETHRU,
         sentVitalsAlertAt: new Date('2019-10-10'),
       })
       sandbox.stub(db, 'getActiveServerStateMachineLocations').returns([this.testLocation])
       sandbox.stub(db, 'getActiveFirmwareStateMachineLocations').returns([])
 
       sandbox.stub(redis, 'getLatestXeThruSensorData').returns({ timestamp: excessiveRadarTimestamp })
-
-      sandbox.stub(redis, 'getLatestInnosentSensorData').throws('should not have called redis.getLatestInnosentSensorData')
 
       sandbox.stub(redis, 'getLatestDoorSensorData').returns({ timestamp: notExcessiveDoorTimestamp })
 
@@ -283,57 +269,13 @@ describe('vitals.js unit tests: checkHeartbeat', () => {
     })
   })
 
-  describe('when a INS device with a server-side state machine and no existing alerts notices that the latest radar message was longer than the threshold', () => {
+  describe('when a device with a firmware state machine and no existing alerts notices that the latest radar message was longer than the threshold', () => {
     beforeEach(async () => {
-      this.testLocation = locationFactory({ firmwareStateMachine: false, isActive: true, radarType: RADAR_TYPE.INNOSENT, sentVitalsAlertAt: null })
-      sandbox.stub(db, 'getActiveServerStateMachineLocations').returns([this.testLocation])
-      sandbox.stub(db, 'getActiveFirmwareStateMachineLocations').returns([])
-
-      sandbox.stub(redis, 'getLatestXeThruSensorData').throws('should not have called redis.getLatestXeThruSensorData')
-
-      sandbox.stub(redis, 'getLatestInnosentSensorData').returns({ timestamp: excessiveRadarTimestamp })
-
-      sandbox.stub(redis, 'getLatestDoorSensorData').returns({ timestamp: notExcessiveDoorTimestamp })
-
-      sandbox.stub(redis, 'getLatestHeartbeat').throws('should not have called redis.getLatestHeartbeat')
-
-      await vitals.checkHeartbeat()
-    })
-
-    it('should send a radar disconnection message to Sentry', () => {
-      expect(helpers.logSentry).to.have.been.calledOnceWithExactly(`Radar sensor down at ${this.testLocation.locationid}`)
-    })
-
-    it('should send an initial disconnection messages to the client', () => {
-      expect(this.sendDisconnectionMessageStub).to.be.calledOnceWithExactly(this.testLocation.locationid, this.testLocation.displayName)
-    })
-
-    it('should not send any disconnection reminder messages to the client', () => {
-      expect(this.sendDisconnectionReminderStub).to.not.be.called
-    })
-
-    it('should not send any reconnection messages to the client', () => {
-      expect(this.sendReconnectionMessageStub).to.not.be.called
-    })
-
-    it('should update the sentVitalsAlertAt to the current time', () => {
-      expect(db.updateSentAlerts).to.be.calledOnceWithExactly(this.testLocation.locationid, true)
-    })
-
-    it('should not log any errors', () => {
-      expect(helpers.logError).to.not.be.called
-    })
-  })
-
-  describe('when a INS device with a firmware state machine and no existing alerts notices that the latest radar message was longer than the threshold', () => {
-    beforeEach(async () => {
-      this.testLocation = locationFactory({ firmwareStateMachine: true, isActive: true, radarType: RADAR_TYPE.INNOSENT, sentVitalsAlertAt: null })
+      this.testLocation = locationFactory({ firmwareStateMachine: true, isActive: true, sentVitalsAlertAt: null })
       sandbox.stub(db, 'getActiveServerStateMachineLocations').returns([])
       sandbox.stub(db, 'getActiveFirmwareStateMachineLocations').returns([this.testLocation])
 
       sandbox.stub(redis, 'getLatestXeThruSensorData').throws('should not have called redis.getLatestXeThruSensorData')
-
-      sandbox.stub(redis, 'getLatestInnosentSensorData').throws('should not have called redis.getLatestInnosentSensorData')
 
       sandbox.stub(redis, 'getLatestDoorSensorData').throws('should not have called redis.getLatestDoorSensorData')
 
@@ -367,20 +309,17 @@ describe('vitals.js unit tests: checkHeartbeat', () => {
     })
   })
 
-  describe('when a INS device with a firmware state machine and an existing alert is no longer exceeding radar thresholds', () => {
+  describe('when a device with a firmware state machine and an existing alert is no longer exceeding radar thresholds', () => {
     beforeEach(async () => {
       this.testLocation = locationFactory({
         firmwareStateMachine: true,
         isActive: true,
-        radarType: RADAR_TYPE.INNOSENT,
         sentVitalsAlertAt: new Date('2020-10-10T10:10:10.000Z'),
       })
       sandbox.stub(db, 'getActiveServerStateMachineLocations').returns([])
       sandbox.stub(db, 'getActiveFirmwareStateMachineLocations').returns([this.testLocation])
 
       sandbox.stub(redis, 'getLatestXeThruSensorData').throws('should not have called redis.getLatestXeThruSensorData')
-
-      sandbox.stub(redis, 'getLatestInnosentSensorData').throws('should not have called redis.getLatestInnosentSensorData')
 
       sandbox.stub(redis, 'getLatestDoorSensorData').throws('should not have called redis.getLatestDoorSensorData')
 
@@ -414,20 +353,17 @@ describe('vitals.js unit tests: checkHeartbeat', () => {
     })
   })
 
-  describe('when a INS device with a firmware state machine and an existing alert is still exceeding the radar threshold but it has not yet exceeded the subsequent vitals threshold', () => {
+  describe('when a device with a firmware state machine and an existing alert is still exceeding the radar threshold but it has not yet exceeded the subsequent vitals threshold', () => {
     beforeEach(async () => {
       this.testLocation = locationFactory({
         firmwareStateMachine: true,
         isActive: true,
-        radarType: RADAR_TYPE.INNOSENT,
         sentVitalsAlertAt: new Date(),
       })
       sandbox.stub(db, 'getActiveServerStateMachineLocations').returns([])
       sandbox.stub(db, 'getActiveFirmwareStateMachineLocations').returns([this.testLocation])
 
       sandbox.stub(redis, 'getLatestXeThruSensorData').throws('should not have called redis.getLatestXeThruSensorData')
-
-      sandbox.stub(redis, 'getLatestInnosentSensorData').throws('should not have called redis.getLatestInnosentSensorData')
 
       sandbox.stub(redis, 'getLatestDoorSensorData').throws('should not have called redis.getLatestDoorSensorData')
 
@@ -461,20 +397,17 @@ describe('vitals.js unit tests: checkHeartbeat', () => {
     })
   })
 
-  describe('when a Xethru device with a server-side state machine and an existing alert is still exceeding the radar threshold and has exceeded the subsequent vitals threshold', () => {
+  describe('when a device with a firmware side state machine and an existing alert is still exceeding the radar threshold and has exceeded the subsequent vitals threshold', () => {
     beforeEach(async () => {
       this.testLocation = locationFactory({
         firmwareStateMachine: true,
         isActive: true,
-        radarType: RADAR_TYPE.INNOSENT,
         sentVitalsAlertAt: new Date('2019-10-10'),
       })
       sandbox.stub(db, 'getActiveServerStateMachineLocations').returns([])
       sandbox.stub(db, 'getActiveFirmwareStateMachineLocations').returns([this.testLocation])
 
       sandbox.stub(redis, 'getLatestXeThruSensorData').throws('should not have called redis.getLatestXeThruSensorData')
-
-      sandbox.stub(redis, 'getLatestInnosentSensorData').throws('should not have called redis.getLatestInnosentSensorData')
 
       sandbox.stub(redis, 'getLatestDoorSensorData').throws('should not have called redis.getLatestDoorSensorData')
 

--- a/server/testingHelpers.js
+++ b/server/testingHelpers.js
@@ -4,7 +4,6 @@ const { fill } = require('lodash')
 // In-house dependencies
 const { factories, helpers } = require('brave-alert-lib')
 const Location = require('./Location')
-const RADAR_TYPE = require('./RadarTypeEnum')
 
 function getRandomInt(minValue, maxValue) {
   const min = Math.ceil(minValue)
@@ -26,11 +25,6 @@ function randomXethruStream(fastmin, fastmax, slowmin, slowmax, length) {
   return array
 }
 
-function randomInnosentStream(min, max, length) {
-  const array = fill(Array(length), { inPhase: getRandomInt(min, max) })
-  return array
-}
-
 async function locationDBFactory(db, overrides = {}) {
   // prettier-ignore
   const location = await db.createLocation(
@@ -44,7 +38,6 @@ async function locationDBFactory(db, overrides = {}) {
     overrides.displayName !== undefined ? overrides.displayName : 'fakeLocationName',
     overrides.doorCoreId !== undefined ? overrides.doorCoreId : 'fakeDoorParticleId',
     overrides.radarCoreId !== undefined ? overrides.radarCoreId : 'fakeRadarParticleId',
-    overrides.radarType !== undefined ? overrides.radarType : RADAR_TYPE.INNOSENT,
     overrides.isActive !== undefined ? overrides.isActive : true,
     overrides.firmwareStateMachine !== undefined ? overrides.firmwareStateMachine : true,
     overrides.sirenParticleId !== undefined ? overrides.sirenParticleId : 'fakeSirenParticleId',
@@ -66,7 +59,6 @@ function locationFactory(overrides = {}) {
     overrides.sentVitalsAlertAt !== undefined ? overrides.sentVitalsAlertAt : null,
     overrides.doorCoreId !== undefined ? overrides.doorCoreId : 'fakeDoorParticleId',
     overrides.radarCoreId !== undefined ? overrides.radarCoreId : 'fakeRadarParticleId',
-    overrides.radarType !== undefined ? overrides.radarType : RADAR_TYPE.INNOSENT,
     overrides.twilioNumber !== undefined ? overrides.twilioNumber : '+17775559999',
     overrides.initialTimer !== undefined ? overrides.initialTimer : 1,
     overrides.isActive !== undefined ? overrides.isActive : true,
@@ -105,5 +97,4 @@ module.exports = {
   locationFactory,
   printRandomIntArray,
   randomXethruStream,
-  randomInnosentStream,
 }

--- a/server/vitals.js
+++ b/server/vitals.js
@@ -5,7 +5,6 @@ const Validator = require('express-validator')
 const { helpers } = require('brave-alert-lib')
 const redis = require('./db/redis')
 const db = require('./db/db')
-const RADAR_TYPE = require('./RadarTypeEnum')
 
 let braveAlerter
 
@@ -53,13 +52,8 @@ async function checkHeartbeat() {
     let latestDoor
 
     try {
-      if (location.radarType === RADAR_TYPE.XETHRU) {
-        const xeThruData = await redis.getLatestXeThruSensorData(location.locationid)
-        latestRadar = convertToSeconds(xeThruData.timestamp)
-      } else if (location.radarType === RADAR_TYPE.INNOSENT) {
-        const innosentData = await redis.getLatestInnosentSensorData(location.locationid)
-        latestRadar = convertToSeconds(innosentData.timestamp)
-      }
+      const xeThruData = await redis.getLatestXeThruSensorData(location.locationid)
+      latestRadar = convertToSeconds(xeThruData.timestamp)
       const doorData = await redis.getLatestDoorSensorData(location.locationid)
       latestDoor = convertToSeconds(doorData.timestamp)
       const redisTime = await redis.getCurrentTimeinSeconds()


### PR DESCRIPTION
- `/api/devicevitals` was originally intended to allow us to display signal strength on the dashboard, but was never fully implemented and is not currently being used at all (i.e. no devices are actually calling this endpoint).
- We decided awhile ago to skip over Sensors v3.0 (INS + SSM). This means that right now, all SSM sensors are XeThru and all FSM sensors are INS. So we don't need any of the state machine code on the backend for INS radars. This meant that we could remove the `radar_type` column from the DB, the `innosent:*` key from Redis, and the `/api/innosent` API endpoint that was intended to be called be a Particle webhook.

## Test plan
- :heavy_check_mark: Deploy to Senors Dev
- :heavy_check_mark: Run smoketests
- :heavy_check_mark: Create real alerts in my bathroom
   - :heavy_check_mark: XeThru Duration
   - :heavy_check_mark: XeThru Stillness
   - :heavy_check_mark:  INS Duration
   - :heavy_check_mark: INS Stillness
- :heavy_check_mark: Export CSV (see that Radar Type is correctly inferred from `firmware_state_machine`)
- :heavy_check_mark: Dashboard
   - :heavy_check_mark: New Location
   - :heavy_check_mark: Edit Location