### PR TITLE
Improved Door Heartbeat Debug Publishes (CU-2chv6je)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,11 +32,13 @@ the code was deployed.
 - Sensors Vitals cache table of only the most recent heartbeat from each locationid (CU-2atyr1z).
 - Ability to turn on/off DB debug logs (CU-2atyr1z).
 - Links on the Vitals the Client Vitals page to the Client and Location pages.
+- If debug flag is on, logging of raw door sensor data (CU-2chv6je)
 
 ### Changed
 
 - Chatbot text messages no longer assume that the Sensor is installed in a bathroom (CU-271q62d).
 - Sensors Vitals pages now show sensors which have never sent a heartbeat message.
+- Debug log flag now global (CU-2chv6je)
 
 ### Removed
 

--- a/firmware/boron-ins-fsm/src/debugFlags.h
+++ b/firmware/boron-ins-fsm/src/debugFlags.h
@@ -1,0 +1,6 @@
+#ifndef DEBUG_FLAGS_H
+#define DEBUG_FLAGS_H
+
+extern bool stateMachineDebugFlag; 
+
+#endif

--- a/firmware/boron-ins-fsm/src/im21door.h
+++ b/firmware/boron-ins-fsm/src/im21door.h
@@ -1,20 +1,6 @@
 /*
  * Brave firmware state machine for single Boron
  * written by Heidi Fedorak, Apr 2021
- * 
- * 
- * IM21 door sensor status byte can be one of:
- * 
- * 0x00 - closed
- * 0x04 - closed + low battery
- * 0x08 - closed + heartbeat
- * 0x0C - closed + heartbeat + low battery
-
- * 0x02 - open
- * 0x06 - open + low battery
- * 0x0A - open + heartbeat
- * 0x0E - open + heartbeat + low battery 
- * 
  */
 
 #ifndef IM21DOOR_H

--- a/firmware/boron-ins-fsm/src/stateMachine.cpp
+++ b/firmware/boron-ins-fsm/src/stateMachine.cpp
@@ -8,6 +8,7 @@
 #include "im21door.h"
 #include "ins3331.h"
 #include "flashAddresses.h"
+#include "debugFlags.h"
 #include <queue>
 
 //define and initialize state machine pointer


### PR DESCRIPTION
When debugging publishes are turned on, publish the raw advertising data from the door sensor whenever it sends a heartbeat. 
Testing that is done: 
- When door sensor sends a heartbeat, the particle console receives 1-4 publishes of the door sensor raw data, and that data is of expected values. 
- When publishes are off, door sensor does not publish heartbeats. 