### PR TITLE
A couple of things that don't have Tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ the code was deployed.
 
 ## [Unreleased]
 
+### Changed
+
+- Request for incident category text message to imply that they don't need to respond immediately.
+
 ### Added
 
 - Console function to enable developers to force reset and bypass DEVICE_RESET_THRESHOLD (CU-2e5adgd).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ the code was deployed.
 ### Changed
 
 - Request for incident category text message to imply that they don't need to respond immediately.
+- Production deployment instructions in the README.
 
 ### Added
 

--- a/server/BraveAlerterConfigurator.js
+++ b/server/BraveAlerterConfigurator.js
@@ -179,7 +179,7 @@ class BraveAlerterConfigurator {
     switch (fromAlertState) {
       case CHATBOT_STATE.STARTED:
       case CHATBOT_STATE.WAITING_FOR_REPLY:
-        returnMessage = `Please respond with the number corresponding to the incident. \n${this.createResponseStringFromIncidentCategories(
+        returnMessage = `Once you have responded, please reply with the number that best describes the incident:\n${this.createResponseStringFromIncidentCategories(
           incidentCategories,
         )}`
         break

--- a/server/test/unit/BraveAlerterConfiguratorTest/getReturnMessageToRespondedByPhoneNumberTest.js
+++ b/server/test/unit/BraveAlerterConfiguratorTest/getReturnMessageToRespondedByPhoneNumberTest.js
@@ -19,7 +19,7 @@ describe('BraveAlerterConfigurator.js unit tests: getReturnMessageToRespondedByP
       'Cat1',
     ])
 
-    expect(returnMessage).to.equal('Please respond with the number corresponding to the incident. \n1 - Cat0\n2 - Cat1\n')
+    expect(returnMessage).to.equal('Once you have responded, please reply with the number that best describes the incident:\n1 - Cat0\n2 - Cat1\n')
   })
 
   it('should get message when STARTED => WAITING_FOR_CATEGORY', () => {
@@ -28,7 +28,7 @@ describe('BraveAlerterConfigurator.js unit tests: getReturnMessageToRespondedByP
       'Cat1',
     ])
 
-    expect(returnMessage).to.equal('Please respond with the number corresponding to the incident. \n1 - Cat0\n2 - Cat1\n')
+    expect(returnMessage).to.equal('Once you have responded, please reply with the number that best describes the incident:\n1 - Cat0\n2 - Cat1\n')
   })
 
   it('should get message when WAITING_FOR_REPLY => WAITING_FOR_CATEGORY', () => {
@@ -38,7 +38,7 @@ describe('BraveAlerterConfigurator.js unit tests: getReturnMessageToRespondedByP
       ['Cat0', 'Cat1'],
     )
 
-    expect(returnMessage).to.equal('Please respond with the number corresponding to the incident. \n1 - Cat0\n2 - Cat1\n')
+    expect(returnMessage).to.equal('Once you have responded, please reply with the number that best describes the incident:\n1 - Cat0\n2 - Cat1\n')
   })
 
   it('should get message when WAITING_FOR_CATEGORY => WAITING_FOR_CATEGORY', () => {


### PR DESCRIPTION
1. Change incident category message text
   - It was brought up at Team Time today that sometimes users think
  they need to give an incident category as soon as the question
  is asked, but they don't know the answer yet, so they will just
  enter in whatever they feel like instead of waiting until they
  know the real incident type. This small text change will hopefully
  imply that they shouldn't reply until they have responded to the
  request for help

2. Updated production deployment instructions in the README
   - Based on a couple of deployments where we actually did things a
  little bit differently than described 
   - Firmware compilation sometimes takes a long time, so we can start
  it before working on the server deployments and then do them in
  parallel if it's taking awhile
   - Added instructions on how to use the Twilio Studio Flows to send
  started and completed text messages to the Responder Phones when
  there is going to be downtime. We've used this a couple of times
  now on Sensors and Buttons and seems to work well enough for our
  purposes
   - Added a clickable table of contents

## Test plan
- :heavy_check_mark: Deploy to Dev
- :heavy_check_mark: Run smoke tests and ensure that the text asking for the incident category has been updated