### PR TITLE
Add Country, Country Subdivision, and Building Type to CSV Export (CU-2c6crcn)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ the code was deployed.
 
 - Console function to enable developers to force reset and bypass DEVICE_RESET_THRESHOLD (CU-2e5adgd).
 - The ability to use different language chatbot messages (CU-2dtutrx).
+- Country, Country Subdivision, and Building Type columns to the CSV Export (CU-2c6crcn).
 
 ## [6.1.0] - 2022-06-27
 

--- a/server/dashboard.js
+++ b/server/dashboard.js
@@ -183,6 +183,9 @@ async function downloadCsv(req, res) {
     'Session State',
     'Alert Type',
     'Session Responded By',
+    'Country',
+    'Country Subdivision',
+    'Building Type',
   ]
 
   const csvParser = new Parser({ fields })

--- a/server/db/038-add-client-extension-table.sql
+++ b/server/db/038-add-client-extension-table.sql
@@ -1,0 +1,58 @@
+DO $migration$
+    DECLARE migrationId INT;
+    DECLARE lastSuccessfulMigrationId INT;
+BEGIN
+    -- The migration ID of this file
+    migrationId := 38;
+
+    -- Get the migration ID of the last file to be successfully run
+    SELECT MAX(id) INTO lastSuccessfulMigrationId
+    FROM migrations;
+
+    -- Only execute this script if its migration ID is next after the last successful migration ID
+    IF migrationId - lastSuccessfulMigrationId = 1 THEN
+        -- ADD SCRIPT HERE
+        -- Add new client extension table
+        CREATE TABLE IF NOT EXISTS clients_extension (
+            client_id uuid PRIMARY KEY REFERENCES clients (id),
+            country text,
+            country_subdivision text,
+            building_type text,
+            created_at timestamptz NOT NULL default now(),
+            updated_at timestamptz NOT NULL default now()
+        );
+
+        -- Add a trigger to update the clients_extension.updated_at column
+        CREATE OR REPLACE FUNCTION trigger_set_timestamp()
+        RETURNS TRIGGER AS $t$
+        BEGIN
+            NEW.updated_at = NOW();
+            RETURN NEW;
+        END;
+        $t$ LANGUAGE plpgsql;
+
+        CREATE TRIGGER set_clients_extension_timestamp
+        BEFORE UPDATE ON clients_extension
+        FOR EACH ROW EXECUTE PROCEDURE trigger_set_timestamp();
+
+        -- Add a trigger to add a row to clients_exension whenever a new row is added to clients
+        CREATE OR REPLACE FUNCTION insert_clients_extension_trigger_fn()
+        RETURNS TRIGGER LANGUAGE PLPGSQL AS $t$
+        BEGIN
+            INSERT INTO clients_extension (client_id) 
+            VALUES (NEW.id)
+            ON CONFLICT (client_id)
+            DO NOTHING;
+            RETURN NEW;
+        END;
+        $t$;
+
+        CREATE TRIGGER add_clients_extension_trigger
+        AFTER INSERT ON clients
+        FOR EACH ROW EXECUTE PROCEDURE insert_clients_extension_trigger_fn();
+
+        -- Update the migration ID of the last file to be successfully run to the migration ID of this file
+        INSERT INTO migrations (id)
+        VALUES (migrationId);
+    END IF;
+END $migration$;

--- a/server/setup_postgresql.sh
+++ b/server/setup_postgresql.sh
@@ -1,38 +1,39 @@
-sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE --set=sslmode=require -c 'CREATE EXTENSION IF NOT EXISTS "pgcrypto"'
-sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE --set=sslmode=require -f ./db/001-setup.sql
-sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE --set=sslmode=require -f ./db/002-hypertable.sql
-sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE --set=sslmode=require -f ./db/003-locations_add_columns_set_defaults.sql
-sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE --set=sslmode=require -f ./db/004-fallbackphone.sql
-sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE --set=sslmode=require -f ./db/005-human_read_location.sql
-sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE --set=sslmode=require -f ./db/006-sessions-alertReason.sql
-sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE --set=sslmode=require -f ./db/007-rename_location_human.sql
-sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE --set=sslmode=require -f ./db/008-drop_unused_tables.sql
-sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE --set=sslmode=require -f ./db/009-add-particlecoreid-to-locations.sql
-sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE --set=sslmode=require -f ./db/010-rename-waiting-for-response.sql
-sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE --set=sslmode=require -f ./db/011-add-radar-type-to-locations.sql
-sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE --set=sslmode=require -f ./db/012-rename-heartbeat-alert-columns.sql
-sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE --set=sslmode=require -f ./db/013-update-locations-table-for-forms.sql
-sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE --set=sslmode=require -f ./db/014-alterfallbackphonenumbertobeanarray.sql
-sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE --set=sslmode=require -f ./db/015-add-api-key-to-locations.sql
-sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE --set=sslmode=require -f ./db/016-alterheatbeackphonenumbertobeanarray.sql
-sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE --set=sslmode=require -f ./db/017-add-is-active-to-locations.sql
-sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE --set=sslmode=require -f ./db/018-refactor-sessions.sql
-sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE --set=sslmode=require -f ./db/019-change-alert-reason-values.sql
-sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE --set=sslmode=require -f ./db/020-add-responded-at-to-sessions.sql
-sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE --set=sslmode=require -f ./db/021-add-client-from-phone-number.sql
-sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE --set=sslmode=require -f ./db/022-add-siren-particle-id.sql
-sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE --set=sslmode=require -f ./db/023-add-responder-push-id.sql
-sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE --set=sslmode=require -f ./db/024-add-sent-low-battery-alert-at-to-locations.sql
-sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE --set=sslmode=require -f ./db/025-add-notifications.sql
-sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE --set=sslmode=require -f ./db/026-add-sent-vitals-alert-at.sql
-sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE --set=sslmode=require -f ./db/027-add-location-created-and-updated-dates.sql
-sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE --set=sslmode=require -f ./db/028-refactor-clients.sql
-sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE --set=sslmode=require -f ./db/029-drop-location-radartype.sql
-sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE --set=sslmode=require -f ./db/030-add-sensor-vitals.sql
-sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE --set=sslmode=require -f ./db/031-add-session-and-sensors-vitals-indices.sql
-sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE --set=sslmode=require -f ./db/032-add-sensor-vitals-cache.sql
-sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE --set=sslmode=require -f ./db/033-remove-siren.sql
-sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE --set=sslmode=require -f ./db/034-alter-session-schema.sql
-sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE --set=sslmode=require -f ./db/035-add-session-responded-by-phone-number.sql
-sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE --set=sslmode=require -f ./db/036-alterresponderphonenumberstobeanarray.sql
-sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE --set=sslmode=require -f ./db/037-add-client-language.sql
+sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE -v "ON_ERROR_STOP=1" --set=sslmode=require -c 'CREATE EXTENSION IF NOT EXISTS "pgcrypto"'
+sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE -v "ON_ERROR_STOP=1" --set=sslmode=require -f ./db/001-setup.sql
+sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE -v "ON_ERROR_STOP=1" --set=sslmode=require -f ./db/002-hypertable.sql
+sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE -v "ON_ERROR_STOP=1" --set=sslmode=require -f ./db/003-locations_add_columns_set_defaults.sql
+sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE -v "ON_ERROR_STOP=1" --set=sslmode=require -f ./db/004-fallbackphone.sql
+sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE -v "ON_ERROR_STOP=1" --set=sslmode=require -f ./db/005-human_read_location.sql
+sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE -v "ON_ERROR_STOP=1" --set=sslmode=require -f ./db/006-sessions-alertReason.sql
+sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE -v "ON_ERROR_STOP=1" --set=sslmode=require -f ./db/007-rename_location_human.sql
+sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE -v "ON_ERROR_STOP=1" --set=sslmode=require -f ./db/008-drop_unused_tables.sql
+sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE -v "ON_ERROR_STOP=1" --set=sslmode=require -f ./db/009-add-particlecoreid-to-locations.sql
+sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE -v "ON_ERROR_STOP=1" --set=sslmode=require -f ./db/010-rename-waiting-for-response.sql
+sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE -v "ON_ERROR_STOP=1" --set=sslmode=require -f ./db/011-add-radar-type-to-locations.sql
+sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE -v "ON_ERROR_STOP=1" --set=sslmode=require -f ./db/012-rename-heartbeat-alert-columns.sql
+sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE -v "ON_ERROR_STOP=1" --set=sslmode=require -f ./db/013-update-locations-table-for-forms.sql
+sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE -v "ON_ERROR_STOP=1" --set=sslmode=require -f ./db/014-alterfallbackphonenumbertobeanarray.sql
+sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE -v "ON_ERROR_STOP=1" --set=sslmode=require -f ./db/015-add-api-key-to-locations.sql
+sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE -v "ON_ERROR_STOP=1" --set=sslmode=require -f ./db/016-alterheatbeackphonenumbertobeanarray.sql
+sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE -v "ON_ERROR_STOP=1" --set=sslmode=require -f ./db/017-add-is-active-to-locations.sql
+sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE -v "ON_ERROR_STOP=1" --set=sslmode=require -f ./db/018-refactor-sessions.sql
+sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE -v "ON_ERROR_STOP=1" --set=sslmode=require -f ./db/019-change-alert-reason-values.sql
+sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE -v "ON_ERROR_STOP=1" --set=sslmode=require -f ./db/020-add-responded-at-to-sessions.sql
+sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE -v "ON_ERROR_STOP=1" --set=sslmode=require -f ./db/021-add-client-from-phone-number.sql
+sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE -v "ON_ERROR_STOP=1" --set=sslmode=require -f ./db/022-add-siren-particle-id.sql
+sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE -v "ON_ERROR_STOP=1" --set=sslmode=require -f ./db/023-add-responder-push-id.sql
+sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE -v "ON_ERROR_STOP=1" --set=sslmode=require -f ./db/024-add-sent-low-battery-alert-at-to-locations.sql
+sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE -v "ON_ERROR_STOP=1" --set=sslmode=require -f ./db/025-add-notifications.sql
+sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE -v "ON_ERROR_STOP=1" --set=sslmode=require -f ./db/026-add-sent-vitals-alert-at.sql
+sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE -v "ON_ERROR_STOP=1" --set=sslmode=require -f ./db/027-add-location-created-and-updated-dates.sql
+sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE -v "ON_ERROR_STOP=1" --set=sslmode=require -f ./db/028-refactor-clients.sql
+sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE -v "ON_ERROR_STOP=1" --set=sslmode=require -f ./db/029-drop-location-radartype.sql
+sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE -v "ON_ERROR_STOP=1" --set=sslmode=require -f ./db/030-add-sensor-vitals.sql
+sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE -v "ON_ERROR_STOP=1" --set=sslmode=require -f ./db/031-add-session-and-sensors-vitals-indices.sql
+sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE -v "ON_ERROR_STOP=1" --set=sslmode=require -f ./db/032-add-sensor-vitals-cache.sql
+sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE -v "ON_ERROR_STOP=1" --set=sslmode=require -f ./db/033-remove-siren.sql
+sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE -v "ON_ERROR_STOP=1" --set=sslmode=require -f ./db/034-alter-session-schema.sql
+sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE -v "ON_ERROR_STOP=1" --set=sslmode=require -f ./db/035-add-session-responded-by-phone-number.sql
+sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE -v "ON_ERROR_STOP=1" --set=sslmode=require -f ./db/036-alterresponderphonenumberstobeanarray.sql
+sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE -v "ON_ERROR_STOP=1" --set=sslmode=require -f ./db/037-add-client-language.sql
+sudo PGPASSWORD=$PG_PASSWORD psql -U $PG_USER -h $PG_HOST -p $PG_PORT -d $PG_DATABASE -v "ON_ERROR_STOP=1" --set=sslmode=require -f ./db/038-add-client-extension-table.sql


### PR DESCRIPTION
- Used an extension table because this data is only every used by
  the CSV export and I didn't want to have to alter the Client
  object to add fields that aren't used anywhere else in the
  program. This also gives the flexibility to easily add and remove
  columns in this table for this need as more reporting requirements
  come up or change
- For now, it is an MVP and is not included
  on the New Client or Update Client pages. If it is missing when
  someone does the CSV export and they need it filled in, they
  can ask someone to add it to the DB
- Just used the `text` datatype to keep this super flexible for now. If we find that it's a problem later, we can introduce an `enum` type.

## Test Plan
- :heavy_check_mark: Deploy to Dev
- :heavy_check_mark: Run smoke tests
- :heavy_check_mark: Export CSV
   - :heavy_check_mark: Old columns still have the correct data
   - :heavy_check_mark: Country column exists and has the correct values
   - :heavy_check_mark: Country Subdivision column exists and has the correct values
   - :heavy_check_mark: Building Type column exists and has the correct values
- :heavy_check_mark: Add country, country subdivision, and/or building type to some and then all of clients to see that it is allowed to be blank and that all the values appear in the exported CSV
- :heavy_check_mark: Create a new Client
   - :heavy_check_mark: Empty row in `clients_extension` is added
- :heavy_check_mark: Update an existing Client that has an entry in the `client_extension` table
- :heavy_check_mark: Update an existing Client that does not have an entry in the `client_extension` table