### PR TITLE
Allow Twilio numbers to be shared across clients (CU-2fk3y8a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ the code was deployed.
 
 ## [Unreleased]
 
+### Changed
+
+- Allow Twilio numbers to be shared across clients (CU-2fk3y8a).
+
 ## [6.2.0] - 2022-07-21
 
 ### Changed

--- a/server/BraveAlerterConfigurator.js
+++ b/server/BraveAlerterConfigurator.js
@@ -10,7 +10,7 @@ class BraveAlerterConfigurator {
   createBraveAlerter() {
     return new BraveAlerter(
       this.getAlertSession.bind(this),
-      this.getAlertSessionByPhoneNumber.bind(this),
+      this.getAlertSessionByPhoneNumbers.bind(this),
       this.getAlertSessionBySessionIdAndAlertApiKey.bind(this),
       this.alertSessionChangedCallback.bind(this),
       this.getLocationByAlertApiKey.bind(this),
@@ -47,9 +47,19 @@ class BraveAlerterConfigurator {
     return alertSession
   }
 
-  async getAlertSessionByPhoneNumber(phoneNumber) {
-    const session = await db.getMostRecentSessionPhone(phoneNumber)
-    const alertSession = await this.createAlertSessionFromSession(session)
+  async getAlertSessionByPhoneNumbers(devicePhoneNumber, responderPhoneNumber) {
+    let alertSession = null
+
+    try {
+      const session = await db.getMostRecentSessionWithPhoneNumbers(devicePhoneNumber, responderPhoneNumber)
+      if (session === null) {
+        return null
+      }
+
+      alertSession = await this.createAlertSessionFromSession(session)
+    } catch (e) {
+      helpers.logError(`getAlertSessionByPhoneNumbers: failed to get and create a new alert session: ${e.toString()}`)
+    }
 
     return alertSession
   }

--- a/server/dashboard.js
+++ b/server/dashboard.js
@@ -203,7 +203,7 @@ async function renderDashboardPage(req, res) {
     const allLocations = await db.getLocations()
 
     for (const location of allLocations) {
-      const recentSession = await db.getMostRecentSession(location.locationid)
+      const recentSession = await db.getMostRecentSessionWithLocationid(location.locationid)
       if (recentSession !== null) {
         const sessionCreatedAt = Date.parse(recentSession.createdAt)
         const timeSinceLastSession = await helpers.generateCalculatedTimeDifferenceString(sessionCreatedAt, db)
@@ -344,7 +344,7 @@ async function renderClientDetailsPage(req, res) {
     const locations = await db.getLocationsFromClientId(currentClient.id)
 
     for (const location of locations) {
-      const recentSession = await db.getMostRecentSession(location.locationid)
+      const recentSession = await db.getMostRecentSessionWithLocationid(location.locationid)
       if (recentSession !== null) {
         const sessionCreatedAt = Date.parse(recentSession.createdAt)
         const timeSinceLastSession = await helpers.generateCalculatedTimeDifferenceString(sessionCreatedAt, db)

--- a/server/db/db.js
+++ b/server/db/db.js
@@ -212,10 +212,10 @@ async function getCurrentTime(pgClient) {
 }
 
 // Gets the most recent session data in the table for a specified location
-async function getMostRecentSession(locationid, pgClient) {
+async function getMostRecentSessionWithLocationid(locationid, pgClient) {
   try {
     const results = await helpers.runQuery(
-      'getMostRecentSession',
+      'getMostRecentSessionWithLocationid',
       `
       SELECT *
       FROM sessions
@@ -315,19 +315,21 @@ async function getClientWithClientId(id, pgClient) {
 }
 
 // Gets the last session data in the table for a specified phone number
-async function getMostRecentSessionPhone(twilioNumber, pgClient) {
+async function getMostRecentSessionWithPhoneNumbers(devicePhoneNumber, responderPhoneNumber, pgClient) {
   try {
     const results = await helpers.runQuery(
-      'getMostRecentSessionPhone',
+      'getMostRecentSessionWithPhoneNumbers',
       `
       SELECT s.*
       FROM sessions AS s
       LEFT JOIN locations AS l ON s.locationid = l.locationid
+      LEFT JOIN clients AS c ON l.client_id = c.id
       WHERE l.twilio_number = $1
+      AND $2 = ANY(c.responder_phone_numbers)
       ORDER BY s.created_at DESC
       LIMIT 1
       `,
-      [twilioNumber],
+      [devicePhoneNumber, responderPhoneNumber],
       pool,
       pgClient,
     )
@@ -1428,8 +1430,8 @@ module.exports = {
   getLocationsFromAlertApiKey,
   getLocationsFromClientId,
   getMostRecentSensorsVitalWithLocationid,
-  getMostRecentSession,
-  getMostRecentSessionPhone,
+  getMostRecentSessionWithLocationid,
+  getMostRecentSessionWithPhoneNumbers,
   getNewNotificationsCountByAlertApiKey,
   getRecentSensorsVitals,
   getRecentSensorsVitalsWithClientId,

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -12,7 +12,7 @@
         "@sentry/node": "^6.2.5",
         "@sentry/tracing": "^6.2.5",
         "axios": "^0.21.2",
-        "brave-alert-lib": "https://github.com/bravetechnologycoop/brave-alert-lib#v8.1.0",
+        "brave-alert-lib": "https://github.com/bravetechnologycoop/brave-alert-lib#v9.0.0",
         "chai-datetime": "^1.8.0",
         "cookie-parser": "^1.4.5",
         "cors": "^2.8.5",
@@ -1443,8 +1443,8 @@
       }
     },
     "node_modules/brave-alert-lib": {
-      "version": "8.1.0",
-      "resolved": "git+ssh://git@github.com/bravetechnologycoop/brave-alert-lib.git#77064ead6dd022f8aa32daa1a9d5e2ca0aa17220",
+      "version": "9.0.0",
+      "resolved": "git+ssh://git@github.com/bravetechnologycoop/brave-alert-lib.git#45c691e78306336a85b2e688be1d50e22d585ecc",
       "dependencies": {
         "@sentry/node": "^6.2.5",
         "@sentry/tracing": "^6.2.5",
@@ -1948,9 +1948,9 @@
       }
     },
     "node_modules/dayjs": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.3.tgz",
-      "integrity": "sha512-xxwlswWOlGhzgQ4TKzASQkUhqERI3egRNqgV4ScR8wlANA/A9tZ7miXa44vTTKEq5l7vWoL5G57bG3zA+Kow0A=="
+      "version": "1.11.4",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.4.tgz",
+      "integrity": "sha512-Zj/lPM5hOvQ1Bf7uAvewDaUcsJoI6JmNqmHhHl3nyumwe0XHwt8sWdOVAPACJzCebL8gQCi+K49w7iKWnGwX9g=="
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -6749,9 +6749,9 @@
       "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="
     },
     "node_modules/twilio": {
-      "version": "3.78.0",
-      "resolved": "https://registry.npmjs.org/twilio/-/twilio-3.78.0.tgz",
-      "integrity": "sha512-XowaxcOeLVNnvxx3t81seLZ/hE/N4z6yt9Vg+KtGhj81gf2ghUa57cr5QtqsI06qnknsGcId5I9X4mRoxZ4nMg==",
+      "version": "3.80.0",
+      "resolved": "https://registry.npmjs.org/twilio/-/twilio-3.80.0.tgz",
+      "integrity": "sha512-ACzeSFqyMViOXDYBQr4CoPoscNWDbHt/gGqU2YpVyVQ/5fsFo/fe+ZAeZBKvrMllP81bhCtPS7H5Lfi9n2cOFw==",
       "dependencies": {
         "axios": "^0.26.1",
         "dayjs": "^1.8.29",
@@ -8385,8 +8385,8 @@
       }
     },
     "brave-alert-lib": {
-      "version": "git+ssh://git@github.com/bravetechnologycoop/brave-alert-lib.git#77064ead6dd022f8aa32daa1a9d5e2ca0aa17220",
-      "from": "brave-alert-lib@https://github.com/bravetechnologycoop/brave-alert-lib#v8.1.0",
+      "version": "git+ssh://git@github.com/bravetechnologycoop/brave-alert-lib.git#45c691e78306336a85b2e688be1d50e22d585ecc",
+      "from": "brave-alert-lib@https://github.com/bravetechnologycoop/brave-alert-lib#v9.0.0",
       "requires": {
         "@sentry/node": "^6.2.5",
         "@sentry/tracing": "^6.2.5",
@@ -8777,9 +8777,9 @@
       }
     },
     "dayjs": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.3.tgz",
-      "integrity": "sha512-xxwlswWOlGhzgQ4TKzASQkUhqERI3egRNqgV4ScR8wlANA/A9tZ7miXa44vTTKEq5l7vWoL5G57bG3zA+Kow0A=="
+      "version": "1.11.4",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.4.tgz",
+      "integrity": "sha512-Zj/lPM5hOvQ1Bf7uAvewDaUcsJoI6JmNqmHhHl3nyumwe0XHwt8sWdOVAPACJzCebL8gQCi+K49w7iKWnGwX9g=="
     },
     "debug": {
       "version": "4.3.4",
@@ -12424,9 +12424,9 @@
       "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="
     },
     "twilio": {
-      "version": "3.78.0",
-      "resolved": "https://registry.npmjs.org/twilio/-/twilio-3.78.0.tgz",
-      "integrity": "sha512-XowaxcOeLVNnvxx3t81seLZ/hE/N4z6yt9Vg+KtGhj81gf2ghUa57cr5QtqsI06qnknsGcId5I9X4mRoxZ4nMg==",
+      "version": "3.80.0",
+      "resolved": "https://registry.npmjs.org/twilio/-/twilio-3.80.0.tgz",
+      "integrity": "sha512-ACzeSFqyMViOXDYBQr4CoPoscNWDbHt/gGqU2YpVyVQ/5fsFo/fe+ZAeZBKvrMllP81bhCtPS7H5Lfi9n2cOFw==",
       "requires": {
         "axios": "^0.26.1",
         "dayjs": "^1.8.29",

--- a/server/package.json
+++ b/server/package.json
@@ -19,7 +19,7 @@
     "@sentry/node": "^6.2.5",
     "@sentry/tracing": "^6.2.5",
     "axios": "^0.21.2",
-    "brave-alert-lib": "https://github.com/bravetechnologycoop/brave-alert-lib#v8.1.0",
+    "brave-alert-lib": "https://github.com/bravetechnologycoop/brave-alert-lib#v9.0.0",
     "chai-datetime": "^1.8.0",
     "cookie-parser": "^1.4.5",
     "cors": "^2.8.5",


### PR DESCRIPTION
- When an SMS arrives from a phone, use both the fromNumber and the
  toNumber to determine the most recent session instead of just the
  toNumber. The toNumber should match one of the Sensors' phone number
  and the fromNumber should match one of the clients'
  responderPhoneNumbers. If there is one that works for both, then it's
  the right session, if not, then it didn't find any
- Note that an SMS can come from any of the client's
  responderPhoneNumbers, not just the one that initially responded to
  the session

## Test Plan
- :heavy_check_mark: Deploy to Dev
- :heavy_check_mark: Run smoketests
- Set up two clients as follows:
   - Client 1:
      - ResponderPhoneNumber: My phone number
      - Location A:
         - TwilioPhoneNumber: Valid dev Twilio number
   - Client 2:
      - ResponderPhoneNumber: James' phone number
      - Location B:
         - TwilioPhoneNumber: SAME valid dev Twilio number

   and run tests:
   - :heavy_check_mark: Create a new session for Location A but none for Location B and reply from my phone number, should advance the chatbot for Location A
   - :heavy_check_mark: Create a new session for Location A but none for Location B and reply from James' phone number, should say "Thank you" because there is no active session
   - :heavy_check_mark: Create a new session for Location A then for Location B and reply from my phone, should advance the chatbot for Location A, reply from my phone again, should advance the chatbot for Location A
   - :heavy_check_mark: Create a new session for Location A then for Location B and reply from my phone, should advance the chatbot for Location A, reply from James' phone, should advance the chatbot for Location B, reply from my phone again, should advance the chatbot for Location A
   - :heavy_check_mark: Create a new session for Location A then for Location B and reply from James' phone, should advance the chatbot for Location B, reply from James' phone again, should advance the chatbot for Location B
   - :heavy_check_mark: Create a new session for Location A then for Location B and reply from James' phone, should advance the chatbot for Location B, reply from my phone, should advance the chatbot for Location A, reply from my phone again, should advance the chatbot for Location A, reply from James' phone again, should advance the chatbot for Location B
- :heavy_check_mark: Make sure multiple responder phones still works
- :heavy_check_mark: Dashboard
   - :heavy_check_mark: Most recent sessions on landing page
   - :heavy_check_mark: Most recent sessions on Client page
   - :heavy_check_mark: Most recent sessions on Location page