### PR TITLE
Update Brave Alert Lib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,11 @@ the code was deployed.
 
 - Allow Twilio numbers to be shared across clients (CU-2fk3y8a).
 - Updated disconnection message and reminder to be accurate for the Boron enclosures (CU-2kwa2zz).
+- Improve Twilio number purchasing error messages.
 
 ### Removed
 
-- Sentry logs when a is heartbeat received with an unknown Particle Core ID (CU-2ju4ky8).
+- Sentry logs when a heartbeat is received with an unknown Particle Core ID (CU-2ju4ky8).
 
 ## [6.2.0] - 2022-07-21
 

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -12,7 +12,7 @@
         "@sentry/node": "^6.2.5",
         "@sentry/tracing": "^6.2.5",
         "axios": "^0.21.2",
-        "brave-alert-lib": "https://github.com/bravetechnologycoop/brave-alert-lib#v9.0.0",
+        "brave-alert-lib": "https://github.com/bravetechnologycoop/brave-alert-lib#v9.1.0",
         "chai-datetime": "^1.8.0",
         "cookie-parser": "^1.4.5",
         "cors": "^2.8.5",
@@ -1443,8 +1443,8 @@
       }
     },
     "node_modules/brave-alert-lib": {
-      "version": "9.0.0",
-      "resolved": "git+ssh://git@github.com/bravetechnologycoop/brave-alert-lib.git#45c691e78306336a85b2e688be1d50e22d585ecc",
+      "version": "9.1.0",
+      "resolved": "git+ssh://git@github.com/bravetechnologycoop/brave-alert-lib.git#dbf3c4129d4a55291657c0e76f455564a5b1ddb7",
       "dependencies": {
         "@sentry/node": "^6.2.5",
         "@sentry/tracing": "^6.2.5",
@@ -8385,8 +8385,8 @@
       }
     },
     "brave-alert-lib": {
-      "version": "git+ssh://git@github.com/bravetechnologycoop/brave-alert-lib.git#45c691e78306336a85b2e688be1d50e22d585ecc",
-      "from": "brave-alert-lib@https://github.com/bravetechnologycoop/brave-alert-lib#v9.0.0",
+      "version": "git+ssh://git@github.com/bravetechnologycoop/brave-alert-lib.git#dbf3c4129d4a55291657c0e76f455564a5b1ddb7",
+      "from": "brave-alert-lib@https://github.com/bravetechnologycoop/brave-alert-lib#v9.1.0",
       "requires": {
         "@sentry/node": "^6.2.5",
         "@sentry/tracing": "^6.2.5",

--- a/server/package.json
+++ b/server/package.json
@@ -19,7 +19,7 @@
     "@sentry/node": "^6.2.5",
     "@sentry/tracing": "^6.2.5",
     "axios": "^0.21.2",
-    "brave-alert-lib": "https://github.com/bravetechnologycoop/brave-alert-lib#v9.0.0",
+    "brave-alert-lib": "https://github.com/bravetechnologycoop/brave-alert-lib#v9.1.0",
     "chai-datetime": "^1.8.0",
     "cookie-parser": "^1.4.5",
     "cors": "^2.8.5",


### PR DESCRIPTION
- So that we will have better error messages when fails to buy
  Twilio numbers

To this version --> https://github.com/bravetechnologycoop/brave-alert-lib/pull/49

## Test Plan
:heavy_check_mark: Pass all the brave-alert-lib tests here: https://github.com/bravetechnologycoop/brave-alert-lib/pull/49