### PR TITLE
Remove Sentry logs for heartbeats from unknown Particle core ID (CU-2ju4ky8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ the code was deployed.
 
 - Allow Twilio numbers to be shared across clients (CU-2fk3y8a).
 
+### Removed
+
+- Sentry logs when a is heartbeat received with an unknown Particle Core ID (CU-2ju4ky8).
+
 ## [6.2.0] - 2022-07-21
 
 ### Changed

--- a/server/vitals.js
+++ b/server/vitals.js
@@ -226,7 +226,7 @@ async function handleHeartbeat(req, res) {
       const location = await db.getLocationFromParticleCoreID(coreId)
       if (!location) {
         const errorMessage = `Bad request to ${req.path}: no location matches the coreID ${coreId}`
-        helpers.logError(errorMessage)
+        helpers.log(errorMessage)
         // Must send 200 so as not to be throttled by Particle (ref: https://docs.particle.io/reference/device-cloud/webhooks/#limits)
         res.status(200).json(errorMessage)
       } else {


### PR DESCRIPTION
- These are annoying and happen regularly as new Sensors are
  being provisioned. Still log them to file because they may still
  indicate something wrong with our configuration, but for the most
  part, these have been happening during expected situations and
  causing a lot of headaches

## Test Plan
- :heavy_check_mark: Deploy to dev
- :heavy_check_mark: Run smoketests
- :heavy_check_mark: Send a heartbeat from an unknown Particle core ID using Postman
   - :heavy_check_mark: See the message is logged to the server 
   - :heavy_check_mark: Do NOT see the message logged to Sentry