### PR TITLE
Do not send the current time as the last received door heartbeat when a Sensor is reset (CU-34atvnc)

### DIFF
--- a/firmware/boron-ins-fsm/src/flashAddresses.h
+++ b/firmware/boron-ins-fsm/src/flashAddresses.h
@@ -30,6 +30,6 @@
 //struct with three unsigned chars (uint8_t)
 #define ADDR_IM_DOORID 20	
 
-//next available address is 20 + 3 = 23
+#define LAST_HEARTBEAT_RECEIVED 24 
 
 #endif

--- a/firmware/boron-ins-fsm/src/imDoorSensor.cpp
+++ b/firmware/boron-ins-fsm/src/imDoorSensor.cpp
@@ -28,8 +28,11 @@ void setupIM(){
 	new Thread("scanBLEThread", threadBLEScanner);
 
   EEPROM.get(LAST_HEARTBEAT_RECEIVED, doorHeartbeatReceived);
-}
 
+  if(doorHeartbeatReceived == 0xFFFFFFFF) {
+    doorHeartbeatReceived = 0;
+  }
+}
 
 //**********loop()*******************
 

--- a/firmware/boron-ins-fsm/src/imDoorSensor.cpp
+++ b/firmware/boron-ins-fsm/src/imDoorSensor.cpp
@@ -15,7 +15,7 @@ os_queue_t bleQueue;
 int missedDoorEventCount = 0;
 bool doorLowBatteryFlag = false;
 bool doorMessageReceivedFlag = false;
-unsigned long doorHeartbeatReceived = millis();
+unsigned long doorHeartbeatReceived;
 unsigned long doorLastMessage = millis();
 
 //**********setup()******************
@@ -27,6 +27,7 @@ void setupIM(){
 	// Create the thread
 	new Thread("scanBLEThread", threadBLEScanner);
 
+  EEPROM.get(LAST_HEARTBEAT_RECEIVED, doorHeartbeatReceived);
 }
 
 
@@ -84,6 +85,7 @@ doorData checkIM(){
     // Checks if the 3rd bit of doorStatus is 1
     if ((currentDoorData.doorStatus & (1 << 3)) != 0){
       doorHeartbeatReceived = millis();
+      EEPROM.put(LAST_HEARTBEAT_RECEIVED, doorHeartbeatReceived);
     }
     //if this is the first door event received after firmware bootup, publish
     if(initialDoorDataFlag){


### PR DESCRIPTION
To implement this change, we can store the time that the last received heartbeat was received on the Boron EEPROM memory. Then, upon restarting the Boron, get the value stored in memory rather than getting the current time. 

IMPORTANT NOTE: millis() gets the time elapsed after the Boron started, so some additional logic to calculate the actual time elapsed between the Boron startup and the value stored in memory will be required to make these changes work.

However, it is important to note that the changes must be able to handle the case where no value is stored in the EEPROM memory yet. One possibility would be to check if the memory at the location is all 1's, since the EEPROM memory initializes by default to all 1s. 