### PR TITLE
Add `GET /api/sensors` and `GET /api/sensors/:sensorId` routes (CU-2chw9e3)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,8 @@ env:
     - LOW_BATTERY_ALERT_TIMEOUT_TEST=2
     - SUBSEQUENT_VITALS_ALERT_THRESHOLD_TEST=2
     - IS_DB_LOGGING=false
+    - PA_API_KEY_PRIMARY_TEST=primaryPAkey
+    - PA_API_KEY_SECONDARY_TEST=secondaryPAkey
 
     # TWILIO_SID_TEST (from https://www.twilio.com/console/voice/project/test-credentials)
     - secure: 'T4IjkoXVMFLcbq7livJ6HxATgk/q2znD4+BdFPn8cuNRc6QzBiNR7AZWoyhRrXqvBv3H3Mq5MIGPmYUW2HRXrihq3VLcp1ZRejXjv3CKqg518yi4JHax7hYesRUE9RoU8SXpOvEQknV9LnNbL030cL7kef1MLd+LepRMvo6B/+3/HuhjZHAmGOj93n8r7Ee1u/OzQDajXKbK0NhsE5HSMsKhwDQe+yyWZKerK1FDx35U4kjmj4kaafNYoLUNwr5S64avBI7kaA45TQ4h4BgPfHVLNwpI+9kVQpCc+wHnEVDd6FzAb3fp8PtYrT1W1hIe9A/+emX2QuMFtHHB6+PNUdPY4q+Wu6RJePcKVw9bWbsMFoAOJ8ZOyL7n/WxfP06FtLx9g8X/FyCNnbtKJlgd+NiIvV45s8QW6tG7/df7m2/FbmENl6++2JsV7HnVyuEITOe8wx/Evnr9Hzlh8zvDfQ3qY8Gb/BusQ7eSeaq/08yE+pZyTDCCh1lyfxaGBC1C6QV5QMwEHPq3U70MdhiXoSKV8Za2GhW96d5dA75yPPqqhc1/MDXZvOUAk/nNs/mzYhlQg2XbR8VML7aSTtP+zwX57kt/5DpXibIPl3wAnXMNhVNPYT3xPnzPRSEzUNAJI/f9qwOTK9eEzspumdqUAxkss5YoE5VWDMHPC4f3Hhk='
@@ -39,7 +41,7 @@ jobs:
     - stage: 'server test'
       language: node_js
       # node_js: node version specified in .nvmrc
-      install: 
+      install:
         - cd server
         - npm ci
       # install Redis

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ the code was deployed.
 
 - Updated to Device OS 3.3.1 (CU-3aru0mb).
 
+### Added
+
+- `GET /api/sensors` route to be used by new Dashboard in PA (CU-2chw9e3).
+- `GET /api/sensors/:sensorId` route to be used by new Dashboard in PA (CU-2chw9e3).
+
 ### Security
 
 - Upgrade dependencies according to Dependabot.

--- a/server/api.js
+++ b/server/api.js
@@ -1,0 +1,86 @@
+/* Conventions for this API:
+ *  - GET method for read actions
+ *  - POST method for update actions
+ *  - PUT method for create actions
+ *  - DELETE method for delete actions
+ *
+ *  - Must contain the `braveKey` API key in the query string (for GET only) or the body (for all other methods)
+ *
+ *  - Must return a JSON object containing the following keys:
+ *    - status:   which will be either "success" or "error"
+ *    - data:     the desired JSON object, if there is one
+ *    - message:  a human-readable explaination of the error, if there was one and this is appropriate. Be careful
+ *                to not include anything that will give an attacker extra information
+ */
+
+// Third-party dependencies
+const Validator = require('express-validator')
+
+// In-house dependencies
+const { helpers } = require('brave-alert-lib')
+const db = require('./db/db')
+
+const paApiKeys = [helpers.getEnvVar('PA_API_KEY_PRIMARY'), helpers.getEnvVar('PA_API_KEY_SECONDARY')]
+
+async function authorize(req, res, next) {
+  if (paApiKeys.indexOf(req.query.braveKey) < 0 && paApiKeys.indexOf(req.body.braveKey)) {
+    helpers.log(`Unauthorized request to: ${req.path}`)
+    res.status(401).send({ status: 'error', message: 'Unauthorized' })
+  } else {
+    return next()
+  }
+}
+
+const validateGetAllSensors = Validator.query(['braveKey']).trim().notEmpty()
+
+async function getAllSensors(req, res) {
+  const validationErrors = Validator.validationResult(req).formatWith(helpers.formatExpressValidationErrors)
+
+  try {
+    if (validationErrors.isEmpty()) {
+      const locations = await db.getLocations()
+
+      if (locations === null) {
+        res.status(400).send({ status: 'error' })
+        return
+      }
+
+      res.status(200).send({ status: 'success', data: locations })
+    } else {
+      res.status(400).send({ status: 'error' })
+    }
+  } catch (e) {
+    res.status(500).send({ status: 'error' })
+  }
+}
+
+const validateGetSensor = [Validator.query(['braveKey']).trim().notEmpty(), Validator.param(['sensorId']).trim().notEmpty()]
+
+async function getSensor(req, res) {
+  const validationErrors = Validator.validationResult(req).formatWith(helpers.formatExpressValidationErrors)
+
+  try {
+    if (validationErrors.isEmpty()) {
+      const location = await db.getLocationData(req.params.sensorId)
+
+      if (location === null) {
+        res.status(400).send({ status: 'error' })
+        return
+      }
+
+      res.status(200).send({ status: 'success', data: location })
+    } else {
+      res.status(400).send({ status: 'error' })
+    }
+  } catch (e) {
+    res.status(500).send({ status: 'error' })
+  }
+}
+
+module.exports = {
+  authorize,
+  getAllSensors,
+  getSensor,
+  validateGetAllSensors,
+  validateGetSensor,
+}

--- a/server/routes.js
+++ b/server/routes.js
@@ -1,5 +1,6 @@
 // In-house dependencies
 const { clickUpHelpers } = require('brave-alert-lib')
+const api = require('./api')
 const dashboard = require('./dashboard')
 const pa = require('./pa')
 const vitals = require('./vitals')
@@ -30,6 +31,9 @@ function configureRoutes(app) {
   app.post('/pa/create-sensor-location', pa.validateCreateSensorLocation, clickUpHelpers.clickUpChecker, pa.handleCreateSensorLocation)
   app.post('/pa/get-sensor-clients', pa.validateGetSensorClients, clickUpHelpers.clickUpChecker, pa.handleGetSensorClients)
   app.post('/pa/sensor-twilio-number', pa.validateSensorTwilioNumber, clickUpHelpers.clickUpChecker, pa.handleSensorTwilioNumber)
+
+  app.get('/api/sensors', api.validateGetAllSensors, api.authorize, api.getAllSensors)
+  app.get('/api/sensors/:sensorId', api.validateGetSensor, api.authorize, api.getSensor)
 
   // TODO add the other routes
 }

--- a/server/test/integration/apiTest/getAllSensorsTest.js
+++ b/server/test/integration/apiTest/getAllSensorsTest.js
@@ -1,0 +1,221 @@
+// Third-party dependencies
+const chai = require('chai')
+const chaiHttp = require('chai-http')
+const sinon = require('sinon')
+const sinonChai = require('sinon-chai')
+const { afterEach, beforeEach, describe, it } = require('mocha')
+
+// In-house dependencies
+const { factories, helpers } = require('brave-alert-lib')
+const db = require('../../../db/db')
+const { server } = require('../../../index')
+const { locationDBFactory } = require('../../../testingHelpers')
+
+// Setup chai
+chai.use(chaiHttp)
+chai.use(sinonChai)
+
+const sandbox = sinon.createSandbox()
+
+const expect = chai.expect
+
+describe('api.js integration tests: getAllSensors', () => {
+  beforeEach(async () => {
+    sandbox.spy(helpers, 'log')
+    sandbox.spy(helpers, 'logError')
+
+    await db.clearTables()
+
+    this.client = await factories.clientDBFactory(db)
+    this.location1 = await locationDBFactory(db, {
+      locationid: 'location1',
+      clientId: this.client.id,
+    })
+    this.location2 = await locationDBFactory(db, {
+      locationid: 'location2',
+      clientId: this.client.id,
+    })
+
+    this.agent = chai.request.agent(server)
+  })
+
+  afterEach(async () => {
+    sandbox.restore()
+    await db.clearTables
+    this.agent.close()
+  })
+
+  describe('for a request that uses the primary PA API key', () => {
+    beforeEach(async () => {
+      this.response = await this.agent.get(`/api/sensors?braveKey=${helpers.getEnvVar('PA_API_KEY_PRIMARY')}`).send()
+    })
+
+    it('should return 200', () => {
+      expect(this.response).to.have.status(200)
+    })
+
+    it('should return status "success"', () => {
+      expect(this.response.body.status).to.equal('success')
+    })
+
+    it('should return all the sensors', async () => {
+      const sensors = this.response.body.data
+
+      chai.assert.equal(sensors.length, 2)
+    })
+
+    it('should return all the sensors', async () => {
+      const sensors = this.response.body.data
+
+      expect({
+        locationid1: sensors[0].locationid,
+        displayName1: sensors[0].displayName,
+        movementThreshold1: sensors[0].movementThreshold,
+        durationTimer1: sensors[0].durationTimer,
+        stillnessTimer1: sensors[0].stillnessTimer,
+        radarCoreId1: sensors[0].radarCoreId,
+        twilioNumber1: sensors[0].twilioNumber,
+        initialTimer1: sensors[0].initialTimer,
+        isActive1: sensors[0].isActive,
+
+        locationid2: sensors[1].locationid,
+        displayName2: sensors[1].displayName,
+        movementThreshold2: sensors[1].movementThreshold,
+        durationTimer2: sensors[1].durationTimer,
+        stillnessTimer2: sensors[1].stillnessTimer,
+        radarCoreId2: sensors[1].radarCoreId,
+        twilioNumber2: sensors[1].twilioNumber,
+        initialTimer2: sensors[1].initialTimer,
+        isActive2: sensors[1].isActive,
+      }).to.eql({
+        locationid1: this.location1.locationid,
+        displayName1: this.location1.displayName,
+        movementThreshold1: this.location1.movementThreshold,
+        durationTimer1: this.location1.durationTimer,
+        stillnessTimer1: this.location1.stillnessTimer,
+        radarCoreId1: this.location1.radarCoreId,
+        twilioNumber1: this.location1.twilioNumber,
+        initialTimer1: this.location1.initialTimer,
+        isActive1: this.location1.isActive,
+
+        locationid2: this.location2.locationid,
+        displayName2: this.location2.displayName,
+        movementThreshold2: this.location2.movementThreshold,
+        durationTimer2: this.location2.durationTimer,
+        stillnessTimer2: this.location2.stillnessTimer,
+        radarCoreId2: this.location2.radarCoreId,
+        twilioNumber2: this.location2.twilioNumber,
+        initialTimer2: this.location2.initialTimer,
+        isActive2: this.location2.isActive,
+      })
+    })
+  })
+
+  describe('for a request that uses the secondary PA API key', () => {
+    beforeEach(async () => {
+      this.response = await this.agent.get(`/api/sensors?braveKey=${helpers.getEnvVar('PA_API_KEY_SECONDARY')}`).send()
+    })
+
+    it('should return 200', () => {
+      expect(this.response).to.have.status(200)
+    })
+
+    it('should return status "success"', () => {
+      expect(this.response.body.status).to.equal('success')
+    })
+
+    it('should return all the sensors', async () => {
+      const sensors = this.response.body.data
+
+      chai.assert.equal(sensors.length, 2)
+    })
+
+    it('should return all the sensors', async () => {
+      const sensors = this.response.body.data
+
+      expect({
+        locationid1: sensors[0].locationid,
+        displayName1: sensors[0].displayName,
+        movementThreshold1: sensors[0].movementThreshold,
+        durationTimer1: sensors[0].durationTimer,
+        stillnessTimer1: sensors[0].stillnessTimer,
+        radarCoreId1: sensors[0].radarCoreId,
+        twilioNumber1: sensors[0].twilioNumber,
+        initialTimer1: sensors[0].initialTimer,
+        isActive1: sensors[0].isActive,
+
+        locationid2: sensors[1].locationid,
+        displayName2: sensors[1].displayName,
+        movementThreshold2: sensors[1].movementThreshold,
+        durationTimer2: sensors[1].durationTimer,
+        stillnessTimer2: sensors[1].stillnessTimer,
+        radarCoreId2: sensors[1].radarCoreId,
+        twilioNumber2: sensors[1].twilioNumber,
+        initialTimer2: sensors[1].initialTimer,
+        isActive2: sensors[1].isActive,
+      }).to.eql({
+        locationid1: this.location1.locationid,
+        displayName1: this.location1.displayName,
+        movementThreshold1: this.location1.movementThreshold,
+        durationTimer1: this.location1.durationTimer,
+        stillnessTimer1: this.location1.stillnessTimer,
+        radarCoreId1: this.location1.radarCoreId,
+        twilioNumber1: this.location1.twilioNumber,
+        initialTimer1: this.location1.initialTimer,
+        isActive1: this.location1.isActive,
+
+        locationid2: this.location2.locationid,
+        displayName2: this.location2.displayName,
+        movementThreshold2: this.location2.movementThreshold,
+        durationTimer2: this.location2.durationTimer,
+        stillnessTimer2: this.location2.stillnessTimer,
+        radarCoreId2: this.location2.radarCoreId,
+        twilioNumber2: this.location2.twilioNumber,
+        initialTimer2: this.location2.initialTimer,
+        isActive2: this.location2.isActive,
+      })
+    })
+  })
+
+  describe('for a request with an invalid PA API key', () => {
+    beforeEach(async () => {
+      this.response = await this.agent.get(`/api/sensors?braveKey=somethingDifferent`).send()
+    })
+
+    it('should return 401', () => {
+      expect(this.response).to.have.status(401)
+    })
+
+    it('should log unauthorized', () => {
+      expect(helpers.log).to.be.calledOnceWithExactly('Unauthorized request to: /api/sensors')
+    })
+  })
+
+  describe('for a request with no PA API key', () => {
+    beforeEach(async () => {
+      this.response = await this.agent.get('/api/sensors').send()
+    })
+
+    it('should return 401', () => {
+      expect(this.response).to.have.status(401)
+    })
+
+    it('should log unauthorized', () => {
+      expect(helpers.log).to.be.calledOnceWithExactly('Unauthorized request to: /api/sensors')
+    })
+  })
+
+  describe('for a request with empty PA API key', () => {
+    beforeEach(async () => {
+      this.response = await this.agent.get('/api/sensors?braveKey=').send()
+    })
+
+    it('should return 401', () => {
+      expect(this.response).to.have.status(401)
+    })
+
+    it('should log unauthorized', () => {
+      expect(helpers.log).to.be.calledOnceWithExactly('Unauthorized request to: /api/sensors')
+    })
+  })
+})

--- a/server/test/integration/apiTest/getSensorTest.js
+++ b/server/test/integration/apiTest/getSensorTest.js
@@ -1,0 +1,147 @@
+// Third-party dependencies
+const chai = require('chai')
+const chaiHttp = require('chai-http')
+const sinon = require('sinon')
+const sinonChai = require('sinon-chai')
+const { afterEach, beforeEach, describe, it } = require('mocha')
+
+// In-house dependencies
+const { factories, helpers } = require('brave-alert-lib')
+const db = require('../../../db/db')
+const { server } = require('../../../index')
+const { locationDBFactory } = require('../../../testingHelpers')
+
+// Setup chai
+chai.use(chaiHttp)
+chai.use(sinonChai)
+
+const sandbox = sinon.createSandbox()
+
+const expect = chai.expect
+
+describe('api.js integration tests: getSensor', () => {
+  beforeEach(async () => {
+    sandbox.spy(helpers, 'log')
+    sandbox.spy(helpers, 'logError')
+
+    await db.clearTables()
+
+    this.client = await factories.clientDBFactory(db)
+    this.location1 = await locationDBFactory(db, {
+      locationid: 'location1',
+      clientId: this.client.id,
+    })
+    this.location2 = await locationDBFactory(db, {
+      locationid: 'location2',
+      clientId: this.client.id,
+    })
+
+    this.agent = chai.request.agent(server)
+  })
+
+  afterEach(async () => {
+    sandbox.restore()
+    await db.clearTables
+    this.agent.close()
+  })
+
+  describe('for a request that uses the primary PA API key and has a valid sensorId', () => {
+    beforeEach(async () => {
+      this.response = await this.agent.get(`/api/sensors/${this.location2.locationid}?braveKey=${helpers.getEnvVar('PA_API_KEY_PRIMARY')}`).send()
+    })
+
+    it('should return 200', () => {
+      expect(this.response).to.have.status(200)
+    })
+
+    it('should return status "success"', () => {
+      expect(this.response.body.status).to.equal('success')
+    })
+
+    it('should return the sensor with the given sensorId', async () => {
+      const sensor = this.response.body.data
+
+      expect({
+        locationid: sensor.locationid,
+        displayName: sensor.displayName,
+        movementThreshold: sensor.movementThreshold,
+        durationTimer: sensor.durationTimer,
+        stillnessTimer: sensor.stillnessTimer,
+        radarCoreId: sensor.radarCoreId,
+        twilioNumber: sensor.twilioNumber,
+        initialTimer: sensor.initialTimer,
+        isActive: sensor.isActive,
+      }).to.eql({
+        locationid: this.location2.locationid,
+        displayName: this.location2.displayName,
+        movementThreshold: this.location2.movementThreshold,
+        durationTimer: this.location2.durationTimer,
+        stillnessTimer: this.location2.stillnessTimer,
+        radarCoreId: this.location2.radarCoreId,
+        twilioNumber: this.location2.twilioNumber,
+        initialTimer: this.location2.initialTimer,
+        isActive: this.location2.isActive,
+      })
+    })
+  })
+
+  describe('for a request that uses the secondary PA API key and has a valid sensorId', () => {
+    beforeEach(async () => {
+      this.response = await this.agent.get(`/api/sensors/${this.location2.locationid}?braveKey=${helpers.getEnvVar('PA_API_KEY_SECONDARY')}`).send()
+    })
+
+    it('should return 200', () => {
+      expect(this.response).to.have.status(200)
+    })
+
+    it('should return status "success"', () => {
+      expect(this.response.body.status).to.equal('success')
+    })
+
+    it('should return the sensor with the given sensorId', async () => {
+      const sensor = this.response.body.data
+
+      expect({
+        locationid: sensor.locationid,
+        displayName: sensor.displayName,
+        movementThreshold: sensor.movementThreshold,
+        durationTimer: sensor.durationTimer,
+        stillnessTimer: sensor.stillnessTimer,
+        radarCoreId: sensor.radarCoreId,
+        twilioNumber: sensor.twilioNumber,
+        initialTimer: sensor.initialTimer,
+        isActive: sensor.isActive,
+      }).to.eql({
+        locationid: this.location2.locationid,
+        displayName: this.location2.displayName,
+        movementThreshold: this.location2.movementThreshold,
+        durationTimer: this.location2.durationTimer,
+        stillnessTimer: this.location2.stillnessTimer,
+        radarCoreId: this.location2.radarCoreId,
+        twilioNumber: this.location2.twilioNumber,
+        initialTimer: this.location2.initialTimer,
+        isActive: this.location2.isActive,
+      })
+    })
+  })
+
+  describe('for a request that has a valid PA API key and has an invalid sensorId', () => {
+    beforeEach(async () => {
+      this.response = await this.agent.get(`/api/sensors/invalidsensorid?braveKey=${helpers.getEnvVar('PA_API_KEY_PRIMARY')}`).send()
+    })
+
+    it('should return 400', () => {
+      expect(this.response).to.have.status(400)
+    })
+  })
+
+  describe('for a request that has a valid PA API key and no sensorId', () => {
+    beforeEach(async () => {
+      this.response = await this.agent.get(`/api/sensor?braveKey=${helpers.getEnvVar('PA_API_KEY_PRIMARY')}`).send()
+    })
+
+    it('should return 404', () => {
+      expect(this.response).to.have.status(404)
+    })
+  })
+})


### PR DESCRIPTION
- To be used by the new Dashboard in PA
- Wanted to do this one first because it will unblock my table creation in PA

## Test plan

- [x] Deploy to dev
- [x] Run smoketests
- [x] `GET /api/sensors` using Postman
   - [x] Returns and error if no api key 
   - [x] Returns 401 if incorrect api key
   - [x] If correct api key
      - [x] Returns 200
      - [x] Returns the full list of sensors 
      - [x] Returns status "success"
- [x] `GET /api/sensors/:sensorId` using Postman
   - [x] Returns an error if no api key 
   - [x] Returns 401 if incorrect api key
   - [x] Returns an error if correct api key but invalid sensorId
   - [x] If correct api key and valid sensorId
      - [x] Returns 200
      - [x] Returns the specified sensor 
      - [x] Returns status "success"