### PR TITLE
Change the door last seen behaviour (CU-34atvnc)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,11 @@ the code was deployed.
 ### Changed
 
 - Updated to Device OS 3.3.1 (CU-3aru0mb).
+<<<<<<< HEAD
 - Replaced locationid with client display name in Sensor disconnection initial and reminder messages (CU-2q39wpk).
+=======
+- Sensor heartbeat API call body key changed from 'doorLastHeartbeat' to 'doorLastMessage' (CU-34atvnc).
+>>>>>>> 1e43212 (Change the door last seen behaviour)
 
 ### Added
 
@@ -25,6 +29,10 @@ the code was deployed.
 ### Security
 
 - Upgrade dependencies according to Dependabot.
+
+### Fixes
+
+- When the sensor starts up, it no longer claims that it just saw the door sensor. The previous 'doorLastSeenAt' is used until a real new door message is received (CU-34atvnc).
 
 ## [7.1.0] - 2022-12-22
 

--- a/firmware/boron-ins-fsm/src/imDoorSensor.cpp
+++ b/firmware/boron-ins-fsm/src/imDoorSensor.cpp
@@ -15,8 +15,8 @@ os_queue_t bleQueue;
 int missedDoorEventCount = 0;
 bool doorLowBatteryFlag = false;
 bool doorMessageReceivedFlag = false;
-unsigned long doorHeartbeatReceived = millis();
-unsigned long doorLastMessage = millis();
+unsigned long doorHeartbeatReceived = 0;
+unsigned long doorLastMessage = 0;
 
 //**********setup()******************
 

--- a/firmware/boron-ins-fsm/src/stateMachine.cpp
+++ b/firmware/boron-ins-fsm/src/stateMachine.cpp
@@ -346,7 +346,7 @@ void getHeartbeat() {
     //     The delay of HEARTBEAT_PUBLISH_DELAY is to restrict the heartbeat publish to 1 instead of 3 because the IM Door Sensor broadcasts 3
     //     messages The doorMessageReceivedFlag is set to true when any IM Door Sensor message is received, but only after a certain threshold
     // 3rd "if condition" is true only if a heartbeat hasnt been published in the last SM_HEARTBEAT_INTERVAL
-    if (lastHeartbeatPublish == 0 || (doorMessageReceivedFlag && millis() - doorHeartbeatReceived >= HEARTBEAT_PUBLISH_DELAY) ||
+    if (lastHeartbeatPublish == 0 || (doorMessageReceivedFlag && ((millis() - doorHeartbeatReceived) >= HEARTBEAT_PUBLISH_DELAY)) ||
         (millis() - lastHeartbeatPublish) > SM_HEARTBEAT_INTERVAL) {
         // from particle docs, max length of publish is 622 chars, I am assuming this includes null char
         char heartbeatMessage[622] = {0};
@@ -359,10 +359,14 @@ void getHeartbeat() {
         // logs whether door sensor is low battery
         writer.name("doorLowBatt").value(doorLowBatteryFlag);
 
-        // logs time in milliseconds since last IM Door Sensor message was received
-        // the particle name is a bit misleading, remains this way because the server uses "doorLastHeartbeat" to check if the IM Door Sensor sensor
-        // has disconnected
-        writer.name("doorLastHeartbeat").value((unsigned int)(millis() - doorLastMessage));
+        if (doorLastMessage == 0) {
+            // Haven't seen any door messages since the device last restarted
+            writer.name("doorLastMessage").value(-1);
+        }
+        else {
+            // logs time in milliseconds since last IM Door Sensor message was received
+            writer.name("doorLastMessage").value((unsigned int)(millis() - doorLastMessage));
+        }
 
         // logs the reason of the last reset
         writer.name("resetReason").value(resetReasonString(resetReason));

--- a/server/testingHelpers.js
+++ b/server/testingHelpers.js
@@ -110,6 +110,20 @@ function sensorsVitalFactory(overrides = {}) {
   )
 }
 
+async function sensorsVitalDBFactory(db, overrides = {}) {
+  // prettier-ignore
+  const sensorVital = await db.logSensorsVital(
+    overrides.locationid !== undefined ? overrides.locationid : 'myLocation',
+    overrides.missedDoorMessages !== undefined ? overrides.missedDoorMessages : 0,
+    overrides.isDoorBatteryLow !== undefined ? overrides.isDoorBatteryLow : false,
+    overrides.doorLastSeenAt !== undefined ? overrides.doorLastSeenAt : new Date('2022-01-03T04:05:06'),
+    overrides.resetReason !== undefined ? overrides.resetReason : 'NONE',
+    overrides.stateTransitions !== undefined ? overrides.stateTransitions : [],
+  )
+
+  return sensorVital
+}
+
 // Sends chai as a parameter so I don't need to include it as a regular dependency in package.json
 async function firmwareAlert(chai, server, coreID, sensorEvent) {
   let response
@@ -136,6 +150,7 @@ module.exports = {
   locationFactory,
   printRandomIntArray,
   randomXethruStream,
+  sensorsVitalDBFactory,
   sensorsVitalFactory,
   sessionDBFactory,
   sessionFactory,


### PR DESCRIPTION
- Because the Boron doesn't have a clock that keeps actual time, the millis() function returns the number of milliseconds since the device started/restarted. We were using this to calculate the last time that we saw a message from the door sensor. This works fine as long as we have seen at least one door message since the device last started up. In the case where we haven't seen any door messages yet, then it will return simply the number of milliseconds since the start up. This is almost certainly going to be less than the number of milliseconds since the actual last door message, and there is no way for the Boron to know how long its been since the last time because it's starting with no information. However, the DB has been tracking this information. So by sending '-1' when the Boron doesn't know how long it's been since the previous time, then the backend can assume that no new messages have come in since the last one that it knows about. This will prevent the bug in CU-34atvnc by making sure that the last seen door value doesn't automatically fall below the threshold on Boron restart.
- Renamed the doorLastHeartbeat to doorLastMessage to be more accurate. I think it was causing some confusion as to its actual implmentation on the other side
- Also updated the README to be more generic with IM21 and IM24 door sensors where appropriate

## Test Plan
- [x] Deploy to dev and to the two Sensors in my bathroom, one with an IM21 and the other with an IM24
- [x] Run smoketests
- [x] Restart Sensors by unplugging and replugging
   - [x] The first Boron heartbeat sends `"doorLastMessage": "-1"`
   - [x] The Sensor Vital is stored in the `sensors_vitals` table with `lastSeenDoor` value the same as the previous row
   - [x] The Sensor Vital is cached in the `sensors_vitals_cache` table with `lastSeenDoor` value the same as the previous row
- [x] Wait for a subsequent Boron heartbeat which should contain a `doorLastMessage` that is not equal to -1 (it will probably be 1000)
   - [x] The Sensor Vital is stored in the `sensors_vitals` table with `lastSeenDoor` value a new value that is the current time minus the number of ms given in `doorLastMessage`
   - [x] The Sensor Vital is cached in the `sensors_vitals_cache` table with `lastSeenDoor` value a new value that is the current time minus the number of ms given in `doorLastMessage`
- [x] Open and close the door a few times, and then wait for another Boron heartbeat which should contain a `doorLastMessage` that is not equal to -1
   - [x] The Sensor Vital is stored in the `sensors_vitals` table with `lastSeenDoor` value a new value that is the current time minus the number of ms given in `doorLastMessage`
   - [x] The Sensor Vital is cached in the `sensors_vitals_cache` table with `lastSeenDoor` value a new value that is the current time minus the number of ms given in `doorLastMessage`
- [x] While the Boron is turned off, erase the row in `sensors_vitals_cache` for one of the Sensors so that the next one will seem like the very first Boron heartbeat for the given Sensor
   - [x] The Sensor Vital is stored in the `sensors_vitals` table with `lastSeenDoor` value a the current time
   - [x] The Sensor Vital is cached in the `sensors_vitals_cache` table with `lastSeenDoor` value that is the current time 
- [x] Trigger a real Stillness Alert and run through the chatbot