### PR TITLE
change bit.ly link in SMS message (CU-2mddwpd)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ the code was deployed.
 
 ## [Unreleased]
 
+### Changed
+
+- Replaced bit.ly link in low battery message with a YouTube link (CU-2mddwpd).
+
 ### Security
 
 - Upgrade dependencies (CU-860phzbq5).

--- a/server/resources/translations/common.en.json
+++ b/server/resources/translations/common.en.json
@@ -11,7 +11,7 @@
   "incidentCategoryRequest": "Once you have responded, please reply with the number that best describes the incident:\n{{ incidentCategories }}",
   "sensorDisconnectionInitial": "The Brave Sensor at {{ deviceDisplayName }} ({{ clientDisplayName }}) has disconnected.\nPlease verify that your door sensor is attached and then press the reset button within the circular hole on the ceiling unit using a pin. If you do not receive a reconnection message shortly after pressing the reset button, contact us by emailing clientsupport@brave.coop.",
   "sensorDisconnectionReminder": "The Brave Sensor at {{ deviceDisplayName }} ({{ clientDisplayName }}) is still disconnected. \nPlease verify that your door sensor is attached and then press the reset button within the circular hole on the ceiling unit using a pin. If you do not receive a reconnection message shortly after pressing the reset button, contact us by emailing clientsupport@brave.coop.",
-  "sensorLowBatteryInitial": "The battery for the {{ deviceDisplayName }} door sensor is low, and needs replacing.\n\nTo watch a video showing how to replace the battery, go to https://bit.ly/sensor-battery",
+  "sensorLowBatteryInitial": "The battery for the {{ deviceDisplayName }} door sensor is low, and needs replacing.\n\nTo watch a video showing how to replace the battery, go to https://youtu.be/-mfk4-qQc4w",
   "sensorReconnection": "The Brave Sensor at {{ deviceDisplayName }} ({{ clientDisplayName }}) has been reconnected.",
   "thankYou": "Thank you"
 }


### PR DESCRIPTION
twilio doesn't like it, so we're changing it to a youtube link : (

testplan:

- [x] make a heartbeat call in which the door low battery is true 
- [x] check text to confirm that change is made
- [x] check that the youtube link redirects to the correct video