### PR TITLE
Don't display locations on Vitals page if client.isDisplayed is false (CU-860ptt5rp)

### DIFF
--- a/server/dashboard.js
+++ b/server/dashboard.js
@@ -105,7 +105,7 @@ async function renderVitalsPage(req, res) {
 
     const sensorsVitals = await db.getRecentSensorsVitals()
     for (const sensorsVital of sensorsVitals) {
-      if (sensorsVital.location.isDisplayed) {
+      if (sensorsVital.location.isDisplayed && sensorsVital.location.client.isDisplayed) {
         viewParams.sensors.push({
           client: sensorsVital.location.client,
           location: sensorsVital.location,


### PR DESCRIPTION
- This was missed in #209 

## Test Plan
- [x] Vitals Page
   - [x] Locations whose Client has is_displayed=false do not appear
   - [x] Locations that have is_displayed=false do not appear
   - [x] Clients dropdown menu contains all Clients with is_displayed = true and only them