### PR TITLE
Allow heartbeatPhoneNumbers to be empty from the Dashboard (CU-2uad09a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ the code was deployed.
 - Only display Clients and Locations in the dashboard if their `is_displayed` is true (CU-860ptt5rp).
 - Only send vitals messages if the relevant `is_sending_vitals` is true (CU-860ptt5rp).
 - Only send Stillness/Duration alerts if the relevant `is_sending_vitals` is true (CU-860ptt5rp).
+- Allow the Heartbeat Phone Numbers field to be empty when adding/editing Clients on the Dashboard (CU-2uad09a).
 
 ## [9.1.0] - 2023-03-13
 

--- a/server/dashboard.js
+++ b/server/dashboard.js
@@ -385,7 +385,7 @@ async function renderClientDetailsPage(req, res) {
 }
 
 const validateNewClient = [
-  Validator.body(['displayName', 'fallbackPhoneNumbers', 'fromPhoneNumber', 'heartbeatPhoneNumbers', 'incidentCategories']).trim().notEmpty(),
+  Validator.body(['displayName', 'fallbackPhoneNumbers', 'fromPhoneNumber', 'incidentCategories']).trim().notEmpty(),
   Validator.body(['reminderTimeout', 'fallbackTimeout']).trim().isInt({ min: 0 }),
   Validator.oneOf([
     Validator.body(['responderPhoneNumbers']).trim().notEmpty(),
@@ -421,6 +421,10 @@ async function submitNewClient(req, res) {
           : null
       const newResponderPushId = data.responderPushId && data.responderPushId.trim() !== '' ? data.responderPushId : null
       const newAlertApiKey = data.alertApiKey && data.alertApiKey.trim() !== '' ? data.alertApiKey : null
+      const newHeartbeatPhoneNumbers =
+        data.heartbeatPhoneNumbers !== undefined && data.heartbeatPhoneNumbers.trim() !== ''
+          ? data.heartbeatPhoneNumbers.split(',').map(phone => phone.trim())
+          : []
 
       const newClient = await db.createClient(
         data.displayName,
@@ -431,7 +435,7 @@ async function submitNewClient(req, res) {
         data.fallbackPhoneNumbers.split(',').map(phone => phone.trim()),
         data.fromPhoneNumber,
         data.fallbackTimeout,
-        data.heartbeatPhoneNumbers.split(',').map(phone => phone.trim()),
+        newHeartbeatPhoneNumbers,
         data.incidentCategories.split(',').map(category => category.trim()),
         true,
         false,
@@ -456,7 +460,6 @@ const validateEditClient = [
     'displayName',
     'fallbackPhoneNumbers',
     'fromPhoneNumber',
-    'heartbeatPhoneNumbers',
     'incidentCategories',
     'isDisplayed',
     'isSendingAlerts',
@@ -499,6 +502,10 @@ async function submitEditClient(req, res) {
           : null
       const newResponderPushId = data.responderPushId && data.responderPushId.trim() !== '' ? data.responderPushId : null
       const newAlertApiKey = data.alertApiKey && data.alertApiKey.trim() !== '' ? data.alertApiKey : null
+      const newHeartbeatPhoneNumbers =
+        data.heartbeatPhoneNumbers !== undefined && data.heartbeatPhoneNumbers.trim() !== ''
+          ? data.heartbeatPhoneNumbers.split(',').map(phone => phone.trim())
+          : []
 
       await db.updateClient(
         data.displayName,
@@ -509,7 +516,7 @@ async function submitEditClient(req, res) {
         data.reminderTimeout,
         data.fallbackPhoneNumbers.split(',').map(phone => phone.trim()),
         data.fallbackTimeout,
-        data.heartbeatPhoneNumbers.split(',').map(phone => phone.trim()),
+        newHeartbeatPhoneNumbers,
         data.incidentCategories.split(',').map(category => category.trim()),
         data.isDisplayed,
         data.isSendingAlerts,

--- a/server/mustache-templates/newClient.mst
+++ b/server/mustache-templates/newClient.mst
@@ -65,7 +65,7 @@
                 <div class="form-group row justify-content-start row-no-gutters">
                     <label for="heartbeatPhoneNumbers" class="col-sm-3 col-form-label">Heartbeat Phone Numbers:</label>
                     <div class="col-sm-5">
-                        <input type="text" class="form-control" name="heartbeatPhoneNumbers" value="{{heartbeatPhoneNumbers}}" required pattern="[+][1]\d{10}([,][+][1]\d{10})*">
+                        <input type="text" class="form-control" name="heartbeatPhoneNumbers" value="{{heartbeatPhoneNumbers}}" pattern="[+][1]\d{10}([,][+][1]\d{10})*">
                         <small id="heartbeatPhoneNumbersHelp" class="form-text text-muted">Each phone number has +1 in front and separated by commas with no dashes or spaces, please (eg. +14445556789,+12223334444,+11231231234)</small>
                     </div>
                 </div>

--- a/server/mustache-templates/updateClient.mst
+++ b/server/mustache-templates/updateClient.mst
@@ -71,7 +71,7 @@
                 <div class="form-group row justify-content-start row-no-gutters">
                     <label for="heartbeatPhoneNumbers" class="col-sm-3 col-form-label">Heartbeat Phone Numbers:</label>
                     <div class="col-sm-5">
-                        <input type="text" class="form-control" name="heartbeatPhoneNumbers" value="{{heartbeatPhoneNumbers}}" required pattern="[+][1]\d{10}([,][+][1]\d{10})*">
+                        <input type="text" class="form-control" name="heartbeatPhoneNumbers" value="{{heartbeatPhoneNumbers}}" pattern="[+][1]\d{10}([,][+][1]\d{10})*">
                         <small id="heartbeatPhoneNumbersHelp" class="form-text text-muted">Each phone number has +1 in front and separated by commas with no dashes or spaces, please (eg. +14445556789,+12223334444,+11231231234)</small>
                     </div>
                 </div>

--- a/server/test/integration/dashboardTest/submitEditClientTest.js
+++ b/server/test/integration/dashboardTest/submitEditClientTest.js
@@ -369,6 +369,82 @@ describe('dashboard.js integration tests: submitEditClient', () => {
     })
   })
 
+  describe('for a request that contains valid non-empty fields but with no heartbeatPhoneNumbers', () => {
+    beforeEach(async () => {
+      await this.agent.post('/login').send({
+        username: helpers.getEnvVar('WEB_USERNAME'),
+        password: helpers.getEnvVar('PASSWORD'),
+      })
+
+      this.newDisplayname = 'New Display Name'
+      this.newFromPhoneNumber = '+17549553216'
+      this.newResponderPhoneNumbers = ['+18885554444']
+      this.newResponderPushId = 'myPushId'
+      this.newAlertApiKey = 'myApiKey'
+      this.fallbackPhoneNumbers = ['+1', '+2', '+3']
+      this.incidentCategories = ['Cat1', 'Cat2']
+      this.reminderTimeout = 5
+      this.fallbackTimeout = 10
+      this.isDisplayed = true
+      this.isSendingAlerts = true
+      this.isSendingVitals = true
+      this.goodRequest = {
+        displayName: this.newDisplayname,
+        fromPhoneNumber: this.newFromPhoneNumber,
+        responderPhoneNumbers: this.newResponderPhoneNumbers.join(','),
+        responderPushId: this.newResponderPushId,
+        alertApiKey: this.newAlertApiKey,
+        fallbackPhoneNumbers: this.fallbackPhoneNumbers.join(','),
+        incidentCategories: this.incidentCategories.join(','),
+        reminderTimeout: this.reminderTimeout,
+        fallbackTimeout: this.fallbackTimeout,
+        isDisplayed: this.isDisplayed,
+        isSendingAlerts: this.isSendingAlerts,
+        isSendingVitals: this.isSendingVitals,
+      }
+
+      this.response = await this.agent.post(`/clients/${this.existingClient.id}`).send(this.goodRequest)
+    })
+
+    it('should return 200', () => {
+      expect(this.response).to.have.status(200)
+    })
+
+    it('should update the client in the database', async () => {
+      const updatedClient = await db.getClientWithClientId(this.existingClient.id)
+
+      expect({
+        displayName: updatedClient.displayName,
+        fromPhoneNumber: updatedClient.fromPhoneNumber,
+        responderPhoneNumbers: updatedClient.responderPhoneNumbers,
+        responderPushId: updatedClient.responderPushId,
+        alertApiKey: updatedClient.alertApiKey,
+        fallbackPhoneNumbers: updatedClient.fallbackPhoneNumbers,
+        heartbeatPhoneNumbers: updatedClient.heartbeatPhoneNumbers,
+        incidentCategories: updatedClient.incidentCategories,
+        reminderTimeout: updatedClient.reminderTimeout,
+        fallbackTimeout: updatedClient.fallbackTimeout,
+        isDisplayed: updatedClient.isDisplayed,
+        isSendingAlerts: updatedClient.isSendingAlerts,
+        isSendingVitals: updatedClient.isSendingVitals,
+      }).to.eql({
+        displayName: this.newDisplayname,
+        fromPhoneNumber: this.newFromPhoneNumber,
+        responderPhoneNumbers: this.newResponderPhoneNumbers,
+        responderPushId: this.newResponderPushId,
+        alertApiKey: this.newAlertApiKey,
+        fallbackPhoneNumbers: this.fallbackPhoneNumbers,
+        heartbeatPhoneNumbers: [],
+        incidentCategories: this.incidentCategories,
+        reminderTimeout: this.reminderTimeout,
+        fallbackTimeout: this.fallbackTimeout,
+        isDisplayed: this.isDisplayed,
+        isSendingAlerts: this.isSendingAlerts,
+        isSendingVitals: this.isSendingVitals,
+      })
+    })
+  })
+
   describe('for a request that contains valid non-empty fields but with no alertApiKey', () => {
     beforeEach(async () => {
       await this.agent.post('/login').send({
@@ -611,7 +687,7 @@ describe('dashboard.js integration tests: submitEditClient', () => {
 
     it('should log the error', () => {
       expect(helpers.log).to.have.been.calledWith(
-        `Bad request to /clients/${this.existingClient.id}: displayName (Invalid value),fallbackPhoneNumbers (Invalid value),fromPhoneNumber (Invalid value),heartbeatPhoneNumbers (Invalid value),incidentCategories (Invalid value),isDisplayed (Invalid value),isSendingAlerts (Invalid value),isSendingVitals (Invalid value),reminderTimeout (Invalid value),fallbackTimeout (Invalid value),responderPhoneNumbers/alertApiKey/responderPushId (Invalid value(s))`,
+        `Bad request to /clients/${this.existingClient.id}: displayName (Invalid value),fallbackPhoneNumbers (Invalid value),fromPhoneNumber (Invalid value),incidentCategories (Invalid value),isDisplayed (Invalid value),isSendingAlerts (Invalid value),isSendingVitals (Invalid value),reminderTimeout (Invalid value),fallbackTimeout (Invalid value),responderPhoneNumbers/alertApiKey/responderPushId (Invalid value(s))`,
       )
     })
   })
@@ -638,7 +714,7 @@ describe('dashboard.js integration tests: submitEditClient', () => {
 
     it('should log the error', () => {
       expect(helpers.log).to.have.been.calledWith(
-        `Bad request to /clients/${this.existingClient.id}: displayName (Invalid value),fallbackPhoneNumbers (Invalid value),fromPhoneNumber (Invalid value),heartbeatPhoneNumbers (Invalid value),incidentCategories (Invalid value),isDisplayed (Invalid value),isSendingAlerts (Invalid value),isSendingVitals (Invalid value),reminderTimeout (Invalid value),fallbackTimeout (Invalid value),responderPhoneNumbers/alertApiKey/responderPushId (Invalid value(s))`,
+        `Bad request to /clients/${this.existingClient.id}: displayName (Invalid value),fallbackPhoneNumbers (Invalid value),fromPhoneNumber (Invalid value),incidentCategories (Invalid value),isDisplayed (Invalid value),isSendingAlerts (Invalid value),isSendingVitals (Invalid value),reminderTimeout (Invalid value),fallbackTimeout (Invalid value),responderPhoneNumbers/alertApiKey/responderPushId (Invalid value(s))`,
       )
     })
   })

--- a/server/test/integration/dashboardTest/submitNewClientTest.js
+++ b/server/test/integration/dashboardTest/submitNewClientTest.js
@@ -299,6 +299,82 @@ describe('dashboard.js integration tests: submitNewClient', () => {
     })
   })
 
+  describe('for a request that contains valid non-empty fields but with no heartbeatPhoneNumbers', () => {
+    beforeEach(async () => {
+      await this.agent.post('/login').send({
+        username: helpers.getEnvVar('WEB_USERNAME'),
+        password: helpers.getEnvVar('PASSWORD'),
+      })
+
+      this.displayName = 'myNewClient'
+      this.fromPhoneNumber = '+19998887777'
+      this.responderPhoneNumbers = ['+16665553333']
+      this.responderPushId = 'pushId'
+      this.alertApiKey = 'myApiKey'
+      this.fallbackPhoneNumbers = ['+1', '+2', '+3']
+      this.incidentCategories = ['Cat1', 'Cat2']
+      this.reminderTimeout = 5
+      this.fallbackTimeout = 10
+      const goodRequest = {
+        displayName: this.displayName,
+        fromPhoneNumber: this.fromPhoneNumber,
+        responderPhoneNumbers: this.responderPhoneNumbers.join(','),
+        responderPushId: this.responderPushId,
+        alertApiKey: this.alertApiKey,
+        fallbackPhoneNumbers: this.fallbackPhoneNumbers.join(','),
+        incidentCategories: this.incidentCategories.join(','),
+        reminderTimeout: this.reminderTimeout,
+        fallbackTimeout: this.fallbackTimeout,
+      }
+
+      this.response = await this.agent.post('/clients').send(goodRequest)
+    })
+
+    it('should return 200', () => {
+      expect(this.response).to.have.status(200)
+    })
+
+    it('should create a single client in the database with the given values', async () => {
+      const clients = await db.getClients()
+
+      expect(
+        clients.map(client => {
+          return {
+            displayName: client.displayName,
+            fromPhoneNumber: client.fromPhoneNumber,
+            responderPhoneNumbers: client.responderPhoneNumbers,
+            responderPushId: client.responderPushId,
+            alertApiKey: client.alertApiKey,
+            fallbackPhoneNumbers: client.fallbackPhoneNumbers,
+            heartbeatPhoneNumbers: client.heartbeatPhoneNumbers,
+            incidentCategories: client.incidentCategories,
+            reminderTimeout: client.reminderTimeout,
+            fallbackTimeout: client.fallbackTimeout,
+            isDisplayed: client.isDisplayed,
+            isSendingAlerts: client.isSendingAlerts,
+            isSendingVitals: client.isSendingVitals,
+          }
+        }),
+      ).to.eql([
+        {
+          displayName: this.displayName,
+          fromPhoneNumber: this.fromPhoneNumber,
+          responderPhoneNumbers: this.responderPhoneNumbers,
+          responderPushId: this.responderPushId,
+          alertApiKey: this.alertApiKey,
+          fallbackPhoneNumbers: this.fallbackPhoneNumbers,
+          heartbeatPhoneNumbers: [],
+          incidentCategories: this.incidentCategories,
+          reminderTimeout: this.reminderTimeout,
+          fallbackTimeout: this.fallbackTimeout,
+          isDisplayed: true,
+          isSendingAlerts: false,
+          isSendingVitals: false,
+        },
+      ])
+    })
+  })
+
   describe('for a request that contains valid non-empty fields but with no responderPushId', () => {
     beforeEach(async () => {
       await this.agent.post('/login').send({
@@ -531,7 +607,7 @@ describe('dashboard.js integration tests: submitNewClient', () => {
 
     it('should log the error', () => {
       expect(helpers.log).to.have.been.calledWith(
-        'Bad request to /clients: displayName (Invalid value),fallbackPhoneNumbers (Invalid value),fromPhoneNumber (Invalid value),heartbeatPhoneNumbers (Invalid value),incidentCategories (Invalid value),reminderTimeout (Invalid value),fallbackTimeout (Invalid value),responderPhoneNumbers/alertApiKey/responderPushId (Invalid value(s))',
+        'Bad request to /clients: displayName (Invalid value),fallbackPhoneNumbers (Invalid value),fromPhoneNumber (Invalid value),incidentCategories (Invalid value),reminderTimeout (Invalid value),fallbackTimeout (Invalid value),responderPhoneNumbers/alertApiKey/responderPushId (Invalid value(s))',
       )
     })
   })
@@ -558,7 +634,7 @@ describe('dashboard.js integration tests: submitNewClient', () => {
 
     it('should log the error', () => {
       expect(helpers.log).to.have.been.calledWith(
-        'Bad request to /clients: displayName (Invalid value),fallbackPhoneNumbers (Invalid value),fromPhoneNumber (Invalid value),heartbeatPhoneNumbers (Invalid value),incidentCategories (Invalid value),reminderTimeout (Invalid value),fallbackTimeout (Invalid value),responderPhoneNumbers/alertApiKey/responderPushId (Invalid value(s))',
+        'Bad request to /clients: displayName (Invalid value),fallbackPhoneNumbers (Invalid value),fromPhoneNumber (Invalid value),incidentCategories (Invalid value),reminderTimeout (Invalid value),fallbackTimeout (Invalid value),responderPhoneNumbers/alertApiKey/responderPushId (Invalid value(s))',
       )
     })
   })


### PR DESCRIPTION
- It is a valid use case to have this field be an empty array. In this case, only the Responder Phone Numbers will receive vitals text messages. Before this code change, we would need to make this happen directly in the DB, which carries the risk of human error. This will be better, and it wasn't a complicated change, so it was worth doing even though the Dashboard is supposed to move to PA

## Test plan
- [x] Deploy to dev
- [x] Add a new client in the Dashboard
   - [x] With nothing in the "Heartbeat Phone Numbers" field - should create client with an empty array of heartbeatPhoneNumbers in the DB
   - [x] With only whitespace in the "Heartbeat Phone Numbers" field - should show show validation error
   - [x] With a valid phone number in the "Heartbeat Phone Numbers" field - should create client
   - [x] With a invalid phone number in the "Heartbeat Phone Numbers" field - should show validation error
- [x] Edit a client in the Dashboard
   - [x] With nothing in the "Heartbeat Phone Numbers" field - should modify client to have an empty array of heartbeatPhoneNumbers in the DB
   - [x] With only whitespace in the "Heartbeat Phone Numbers" field - should show show validation error
   - [x] With a valid phone number in the "Heartbeat Phone Numbers" field - should modify client
   - [x] With a invalid phone number in the "Heartbeat Phone Numbers" field - should show validation error