### PR TITLE
Alert when the door sensor has been tampered with (CU-860pp0zfn)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ the code was deployed.
 ### Added
 
 - Auto-shut off for debug publishes after 8 hours (CU-860r0z9zb).
+- Vitals Alerts for when a door sensor's Tamper Flag changes (CU-860pp0zfn).
+
+### Fixed
+
+- Vitals Alerts for when a door sensor's Low Battery Flag changes.
 
 ## [9.5.0] - 2023-06-02
 

--- a/firmware/README.md
+++ b/firmware/README.md
@@ -466,10 +466,11 @@ Heartbeat
 **Event Data**
 
 1. doorMissedMsg: the number of IM door sensor missed message alerts generated since the previous heartbeat.
-2. doorLowBatt: a boolean that indicates whether the last IM door sensor message received has a "1" on the low battery flag.
-3. doorLastMessage: millis since the last IM door sensor message was received. Counts from 0 upon restart. Returns -1 if hasn't seen any door messages since the most recent restart
-4. resetReason: provides the reason of reset on the first heartbeat since a reset. Otherwise, will equal "NONE".
-5. states: an array that encodes all the state transitions that occured since the previous heartbeat\*, with each subarray representing a single state transition. Subarray data includes:
+1. doorLowBatt: a boolean that indicates whether the last IM door sensor message received has a "1" on the low battery flag. Returns -1 if hasn't seen any door messages since the most recent restart
+1. doorTampered: a boolean that indicates whether the last IM door sensor message received has a "1" on the tamper flag. Returns -1 if hasn't seen any door messages since the most recent restart
+1. doorLastMessage: millis since the last IM door sensor message was received. Counts from 0 upon restart. Returns -1 if hasn't seen any door messages since the most recent restart
+1. resetReason: provides the reason of reset on the first heartbeat since a reset. Otherwise, will equal "NONE".
+1. states: an array that encodes all the state transitions that occured since the previous heartbeat\*, with each subarray representing a single state transition. Subarray data includes:
 
    1. an integer between 0-3, representing the previous state. The number corresponds to the states described in the [state diagram](https://docs.google.com/drawings/d/14JmUKDO-Gs7YLV5bhE67ZYnGeZbBg-5sq0fQYwkhkI0/edit?usp=sharing).
    2. an integer between 0-5, representing the reason of transition out of the previous state. The table to decode the reason is below.

--- a/firmware/boron-ins-fsm/src/imDoorSensor.cpp
+++ b/firmware/boron-ins-fsm/src/imDoorSensor.cpp
@@ -14,6 +14,7 @@ IMDoorID globalDoorID = {0xAA, 0xAA, 0xAA};
 os_queue_t bleQueue;
 int missedDoorEventCount = 0;
 bool doorLowBatteryFlag = false;
+bool doorTamperedFlag = false;
 bool doorMessageReceivedFlag = false;
 unsigned long doorHeartbeatReceived = 0;
 unsigned long doorLastMessage = 0;
@@ -63,8 +64,10 @@ doorData checkIM() {
         static int initialDoorDataFlag = 1;
 
         // Checks if the 2nd bit (counting from 0) of doorStatus is 1
-        // read as: doorLowBatteryFlag is true if doorStatus AND 0b0100 is not 0b0000
-        doorLowBatteryFlag = (currentDoorData.doorStatus & (1 << 2)) != 0;
+        doorLowBatteryFlag = (currentDoorData.doorStatus & 0b0100) != 0;
+
+        // Checks if the 0th bit (counting from 0) of doorStatus is 1
+        doorTamperedFlag = (currentDoorData.doorStatus & 0b0001) != 0;
 
         // After a certain thereshold, the next door message received will trigger a boron heartbeat
         if (millis() - doorLastMessage >= MSG_TRIGGER_SM_HEARTBEAT_THRESHOLD) {

--- a/firmware/boron-ins-fsm/src/imDoorSensor.h
+++ b/firmware/boron-ins-fsm/src/imDoorSensor.h
@@ -49,6 +49,7 @@ extern IMDoorID globalDoorID;
 // used in getHeartbeat()
 extern int missedDoorEventCount;
 extern bool doorLowBatteryFlag;
+extern bool doorTamperedFlag;
 extern bool doorMessageReceivedFlag;
 extern unsigned long doorHeartbeatReceived;
 extern unsigned long doorLastMessage;

--- a/firmware/boron-ins-fsm/src/stateMachine.cpp
+++ b/firmware/boron-ins-fsm/src/stateMachine.cpp
@@ -388,20 +388,24 @@ void getHeartbeat() {
         writer.name("doorMissedMsg").value(missedDoorEventCount);
         missedDoorEventCount = 0;
 
-        // logs whether door sensor is low battery
-        writer.name("doorLowBatt").value(doorLowBatteryFlag);
-
         if (doorLastMessage == 0) {
-            // Haven't seen any door messages since the device last restarted
+            // Haven't seen any door messages since the device last restarted so all of these are unknown at this point
             writer.name("doorLastMessage").value(-1);
+            writer.name("doorLowBatt").value(-1);
+            writer.name("doorTampered").value(-1);
         }
         else {
             // logs time in milliseconds since last IM Door Sensor message was received
             writer.name("doorLastMessage").value((unsigned int)(millis() - doorLastMessage));
+
+            writer.name("doorLowBatt").value(doorLowBatteryFlag);
+
+            writer.name("doorTampered").value(doorTamperedFlag);
         }
 
         // logs the reason of the last reset
         writer.name("resetReason").value(resetReasonString(resetReason));
+
         // subsequent heartbeats will not display reset reason
         resetReason = RESET_REASON_NONE;
 

--- a/server/SensorsVital.js
+++ b/server/SensorsVital.js
@@ -1,5 +1,5 @@
 class SensorsVital {
-  constructor(id, missedDoorMessages, isDoorBatteryLow, doorLastSeenAt, resetReason, stateTransitions, createdAt, location) {
+  constructor(id, missedDoorMessages, isDoorBatteryLow, doorLastSeenAt, resetReason, stateTransitions, createdAt, isTampered, location) {
     this.id = id
     this.missedDoorMessages = missedDoorMessages
     this.isDoorBatteryLow = isDoorBatteryLow
@@ -7,6 +7,7 @@ class SensorsVital {
     this.resetReason = resetReason
     this.stateTransitions = stateTransitions
     this.createdAt = createdAt
+    this.isTampered = isTampered
     this.location = location
   }
 }

--- a/server/dashboard.js
+++ b/server/dashboard.js
@@ -116,6 +116,7 @@ async function renderVitalsPage(req, res) {
           doorLastSeenAgo:
             sensorsVital.doorLastSeenAt !== null ? await helpers.generateCalculatedTimeDifferenceString(sensorsVital.doorLastSeenAt, db) : 'Never',
           isDoorBatteryLow: sensorsVital.isDoorBatteryLow !== null ? sensorsVital.isDoorBatteryLow : 'unknown',
+          isTampered: sensorsVital.isTampered !== null ? sensorsVital.isTampered : 'unknown',
           isSendingAlerts: sensorsVital.location.client.isSendingAlerts && sensorsVital.location.isSendingAlerts,
           isSendingVitals: sensorsVital.location.client.isSendingVitals && sensorsVital.location.isSendingVitals,
         })
@@ -156,6 +157,7 @@ async function renderClientVitalsPage(req, res) {
             doorLastSeenAgo:
               sensorsVital.doorLastSeenAt !== null ? await helpers.generateCalculatedTimeDifferenceString(sensorsVital.doorLastSeenAt, db) : 'Never',
             isDoorBatteryLow: sensorsVital.isDoorBatteryLow !== null ? sensorsVital.isDoorBatteryLow : 'unknown',
+            isTampered: sensorsVital.isTampered !== null ? sensorsVital.isTampered : 'unknown',
             isSendingAlerts: sensorsVital.location.client.isSendingAlerts && sensorsVital.location.isSendingAlerts,
             isSendingVitals: sensorsVital.location.client.isSendingVitals && sensorsVital.location.isSendingVitals,
           })

--- a/server/db/042-add-tamper-flag.sql
+++ b/server/db/042-add-tamper-flag.sql
@@ -1,0 +1,69 @@
+DO $migration$
+    DECLARE migrationId INT;
+    DECLARE lastSuccessfulMigrationId INT;
+BEGIN
+    -- The migration ID of this file
+    migrationId := 42;
+
+    -- Get the migration ID of the last file to be successfully run
+    SELECT MAX(id) INTO lastSuccessfulMigrationId
+    FROM migrations;
+
+    -- Only execute this script if its migration ID is next after the last successful migration ID
+    IF migrationId - lastSuccessfulMigrationId = 1 THEN
+        -- ADD SCRIPT HERE
+
+        -- Don't update the sensors_vitals_cache
+        DROP TRIGGER IF EXISTS create_sensors_vitals_trigger ON sensors_vitals;
+
+        -- Add is_tampered column to sensors_vitals, set it to FALSE, and then make it not nullable
+        ALTER TABLE sensors_vitals
+        ADD COLUMN IF NOT EXISTS is_tampered BOOLEAN;
+
+        UPDATE sensors_vitals
+        SET is_tampered = 'f';
+
+        ALTER TABLE sensors_vitals
+        ALTER COLUMN is_tampered
+        SET NOT NULL;
+
+        -- Add is_tampered column to sensors_vitals_cache, set it to FALSE, and then make it not nullable
+        ALTER TABLE sensors_vitals_cache
+        ADD COLUMN IF NOT EXISTS is_tampered BOOLEAN;
+
+        UPDATE sensors_vitals_cache
+        SET is_tampered = 'f';
+
+        ALTER TABLE sensors_vitals_cache
+        ALTER COLUMN is_tampered
+        SET NOT NULL;
+
+        -- Re-activate trigger with new is_tampered column
+        CREATE OR REPLACE FUNCTION create_sensors_vitals_trigger_fn()
+        RETURNS TRIGGER LANGUAGE PLPGSQL AS $t$
+        BEGIN
+            INSERT INTO sensors_vitals_cache (id, locationid, missed_door_messages, is_door_battery_low, door_last_seen_at, reset_reason, state_transitions, created_at, is_tampered) 
+            VALUES (NEW.id, NEW.locationid, NEW.missed_door_messages, NEW.is_door_battery_low, NEW.door_last_seen_at, NEW.reset_reason, NEW.state_transitions, NEW.created_at, NEW.is_tampered)
+            ON CONFLICT (locationid)
+            DO UPDATE SET
+                id = NEW.id,
+                missed_door_messages = NEW.missed_door_messages,
+                is_door_battery_low = NEW.is_door_battery_low,
+                door_last_seen_at = NEW.door_last_seen_at,
+                reset_reason = NEW.reset_reason,
+                state_transitions = NEW.state_transitions,
+                created_at = NEW.created_at,
+                is_tampered = NEW.is_tampered;
+            RETURN NEW;
+        END;
+        $t$;
+
+        CREATE TRIGGER create_sensors_vitals_trigger
+        BEFORE INSERT OR UPDATE ON sensors_vitals
+        FOR EACH ROW EXECUTE PROCEDURE create_sensors_vitals_trigger_fn();
+
+        -- Update the migration ID of the last file to be successfully run to the migration ID of this file
+        INSERT INTO migrations (id)
+        VALUES (migrationId);
+    END IF;
+END $migration$;

--- a/server/mustache-templates/clientVitals.mst
+++ b/server/mustache-templates/clientVitals.mst
@@ -40,6 +40,7 @@
                             <th scope="col">Last Seen (Sensor)</th>
                             <th scope="col">Last Seen (Door)</th>
                             <th scope="col">Door Battery Low?</th>
+                            <th scope="col">Door Tampered?</th>
                             <th scope="col">Sends Alerts?</th>
                             <th scope="col">Sends Vitals?</th>
                         </tr>
@@ -51,6 +52,7 @@
                                 <td data-toggle="tooltip" data-placement="top" title="{{sensorLastSeenAt}}">{{sensorLastSeenAgo}}</td>
                                 <td data-toggle="tooltip" data-placement="top" title="{{doorLastSeenAt}}">{{doorLastSeenAgo}}</td>
                                 <td>{{isDoorBatteryLow}}</td>
+                                <td>{{isTampered}}</td>
                                 <td>{{#isSendingAlerts}}y{{/isSendingAlerts}}{{^isSendingAlerts}}NOPE{{/isSendingAlerts}}</td>
                                 <td>{{#isSendingVitals}}y{{/isSendingVitals}}{{^isSendingVitals}}NOPE{{/isSendingVitals}}</td>
                             </tr>

--- a/server/mustache-templates/vitals.mst
+++ b/server/mustache-templates/vitals.mst
@@ -36,6 +36,7 @@
                             <th scope="col">Last Seen (Sensor)</th>
                             <th scope="col">Last Seen (Door)</th>
                             <th scope="col">Door Battery Low?</th>
+                            <th scope="col">Door Tampered?</th>
                             <th scope="col">Sends Alerts?</th>
                             <th scope="col">Sends Vitals?</th>
                         </tr>
@@ -48,6 +49,7 @@
                                 <td data-toggle="tooltip" data-placement="top" title="{{sensorLastSeenAt}}">{{sensorLastSeenAgo}}</td>
                                 <td data-toggle="tooltip" data-placement="top" title="{{doorLastSeenAt}}">{{doorLastSeenAgo}}</td>
                                 <td>{{isDoorBatteryLow}}</td>
+                                <td>{{isTampered}}</td>
                                 <td>{{#isSendingAlerts}}y{{/isSendingAlerts}}{{^isSendingAlerts}}NOPE{{/isSendingAlerts}}</td>
                                 <td>{{#isSendingVitals}}y{{/isSendingVitals}}{{^isSendingVitals}}NOPE{{/isSendingVitals}}</td>
                             </tr>

--- a/server/resources/translations/common.en.json
+++ b/server/resources/translations/common.en.json
@@ -11,6 +11,7 @@
   "incidentCategoryRequest": "Once you have responded, please reply with the number that best describes the incident:\n{{ incidentCategories }}",
   "sensorDisconnectionInitial": "The Brave Sensor at {{ deviceDisplayName }} ({{ clientDisplayName }}) has disconnected.\nPlease verify that your door sensor is attached and then press the reset button within the circular hole on the ceiling unit using a pin. If you do not receive a reconnection message shortly after pressing the reset button, contact us by emailing clientsupport@brave.coop.",
   "sensorDisconnectionReminder": "The Brave Sensor at {{ deviceDisplayName }} ({{ clientDisplayName }}) is still disconnected. \nPlease verify that your door sensor is attached and then press the reset button within the circular hole on the ceiling unit using a pin. If you do not receive a reconnection message shortly after pressing the reset button, contact us by emailing clientsupport@brave.coop.",
+  "sensorIsTampered": "The door sensor at {{ deviceDisplayName }} is not fully attached to the door. If you require a replacement door sensor or have any questions about this, contact us by emailing clientsupport@brave.coop.",
   "sensorLowBatteryInitial": "The battery for the {{ deviceDisplayName }} door sensor is low, and needs replacing.\n\nTo watch a video showing how to replace the battery, go to https://youtu.be/-mfk4-qQc4w",
   "sensorReconnection": "The Brave Sensor at {{ deviceDisplayName }} ({{ clientDisplayName }}) has been reconnected.",
   "thankYou": "Thank you"

--- a/server/testingHelpers.js
+++ b/server/testingHelpers.js
@@ -115,6 +115,7 @@ function sensorsVitalFactory(overrides = {}) {
     overrides.resetReason !== undefined ? overrides.resetReason : 'NONE',
     overrides.stateTransitions !== undefined ? overrides.stateTransitions : '[]',
     overrides.createdAt !== undefined ? overrides.createdAt : '2021-05-05T19:37:50.176Z',
+    overrides.isTampered !== undefined ? overrides.isTampered : false,
     overrides.location !== undefined ? overrides.location : locationFactory(),
   )
 }
@@ -128,6 +129,7 @@ async function sensorsVitalDBFactory(db, overrides = {}) {
     overrides.doorLastSeenAt !== undefined ? overrides.doorLastSeenAt : new Date('2022-01-03T04:05:06'),
     overrides.resetReason !== undefined ? overrides.resetReason : 'NONE',
     overrides.stateTransitions !== undefined ? overrides.stateTransitions : [],
+    overrides.isTampered !== undefined ? overrides.isTampered : false,
   )
 
   return sensorVital


### PR DESCRIPTION
    Track the door sensor tamper flag and alert about it
    
    - When the firmware doesn't know the value of the tamper flag, it sends
      -1, to match what we do about the time since last door message
    - Changed the door low battery flag to also sent -1 if it is unknown, to
      be consistent with the others. It was probably giving us fake
      battery-no-longer-low messages the way that it was before
    - Changed firmware to use binary values `0b0100` instead of the bitwise
      operation `(1 << 2)` to save on execution cycles and because I think
      that it's just as clear what it means that way
    - Updated the DB to store the latest tamper flag in the sensors_vitals
      and sensors_vitals_cache tables
    - Updated the dashboard to show the latest Tamper flag value on the
      Vitals pages
    - Sends a message to the Responder and Heartbeat Phone Numbers whenever
      the tamper flag changes from true to false or from false to true.
      Purposely did not send the message again on a schedule like we do with
      disconnection and low batteries because there will be instances where
      the tamper flag will always be on and that will be normal for a
      particular bathrooms; we don't want to annoy the clients in this case


## Test Plan
- [x] Deploy to dev server and my local Sensor
- [x] Restart the real Sensor
   - [x] See in Particle Heartbeat message that low battery flag, door tampered flag, and door last message are all -1 and check that values are recorded in `sensors_vitals` and `sensors_vitals_cache`
   - [x] See a heartbeat where low battery flag, door tampered flag, and door last message are all not -1 and check that values are recorded in `sensors_vitals` and `sensors_vitals_cache`
   - [x] Pair with a IM21 door sensor and see that the `doorTampered` is `false`
- [x] For a Sensor that has never had any Heartbeat Messages (i.e. `sensors_vitals` and `sensors_vitals_cache` have no rows for that Sensors). When a Heartbeat message arrives before the door has sent any messages (i.e. the doorLastSeen = -1, tampered = -1, and low battery = -1) 
   - [x] A row is added to `sensors_vitals` and to `sensors_vitals_cache` with low battery flag is false, door tampered is false, and door last message is the current time
- [x] For Heartbeat Messages after the door has sent messages
   - [x] Low battery flag of 1 is stored as True, 0 is stored as False in the DB
   - [x] Tamper flag of 1 is stored as True, 0 is stored as False in the DB
   - [x] door last message milliseconds are converted to the right datetime in the DB
- [x] If the previous SensorsVital had tamper flag 0
   - [x] If a new Heartbeat message comes in with tamper flag 1, then 
      - [x] tampered text message is sent to Responder Phone (unless not sending vitals)
      - [x] tampered text message is sent to Heartbeat Phones (unless not sending vitals)
      - [x] tampered Sentry message is logged
      - [x] tampered = 1 is stored in both `sensors_vitals` and `sensors_vitals_cache`
   - [x] If a new Heartbeat message comes in with tamper flag 0, then 
      - [x] No messages or logs are sent
      - [x] tampered = 0 is stored in both `sensors_vitals` and `sensors_vitals_cache`
   - [x] If a new Heartbeat message comes in with tamper flag -1, then
      - [x] No messages or logs are sent
      - [x] The previous tampered value is stored in both `sensors_vitals` and `sensors_vitals_cache`
- [x] If the previous SensorsVital had tamper flag 1
   - [x] If a new Heartbeat message comes in with tamper flag 1, then
      - [x] No messages or logs are sent
      - [x] tampered = 1 is stored in both `sensors_vitals` and `sensors_vitals_cache`
   - [x] If a new Heartbeat message comes in with tamper flag 0, then
      - [x] No messages or logs are sent
      - [x] tampered = 0 is stored in both `sensors_vitals` and `sensors_vitals_cache`
   - [x] If a new Heartbeat message comes in with tamper flag -1, then
      - [x] No messages or logs are sent
      - [x] The previous tampered value is stored in both `sensors_vitals` and `sensors_vitals_cache`
- [x] If the previous SensorsVital had low battery flag 0 and hasn't sent a low battery alert at all or sent a low battery alert longer ago than the limit
   - [x] If a new Heartbeat message comes in with low battery flag 1, then 
      - [x] low battery text message is sent to Responder Phone (unless not sending vitals)
      - [x] low battery text message is sent to Heartbeat Phones (unless not sending vitals)
      - [x] low battery Sentry message is logged
      - [x] low battery = 1 is stored in both `sensors_vitals` and `sensors_vitals_cache`
   - [x] If a new Heartbeat message comes in with low battery flag 0, then 
      - [x] No messages or logs are sent
      - [x] low battery = 0 is stored in both `sensors_vitals` and `sensors_vitals_cache`
   - [x] If a new Heartbeat message comes in with low battery flag -1, then
      - [x] No messages or logs are sent
      - [x] The previous low battery value is stored in both `sensors_vitals` and `sensors_vitals_cache`
- [x] If the previous SensorsVital had low battery flag 1
   - [x] If a new Heartbeat message comes in with low battery flag 1 and it has sent a low battery alert within the limit, then
      - [x] No messages or logs are sent
      - [x] low battery = 1 is stored in both `sensors_vitals` and `sensors_vitals_cache`
   - [x] If a new Heartbeat message comes in with low battery flag 1 and it sent a low battery alert longer ago than the limit,  then
      - [x] reminder low battery text message is sent to Responder Phone (unless not sending vitals)
      - [x] reminder low battery text message is sent to Heartbeat Phones (unless not sending vitals)
      - [x] reminder low battery Sentry message is logged
      - [x] low battery = 1 is stored in both `sensors_vitals` and `sensors_vitals_cache`
   - [x] If a new Heartbeat message comes in with low battery flag 0, then
      - [x] No messages or logs are sent
      - [x] low battery = 0 is stored in both `sensors_vitals` and `sensors_vitals_cache`
   - [x] If a new Heartbeat message comes in with low battery flag -1, then
      - [x] No messages or logs are sent
      - [x] The previous low battery value is stored in both `sensors_vitals` and `sensors_vitals_cache`
- [x] Dashboard Vitals Page
   - [x] Has a tampered column
   - [x] Tampered column shows "true", "false", or "unknown" based on value in DB
- [x] Dashboard Clients Vitals Page
   - [x] Has a tampered column
   - [x] Tampered column shows "true", "false", or "unknown" based on value in DB