### PR TITLE
Fix inititalization of Long Stillness Timer (CU-860r11fng)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ the code was deployed.
 
 ## [Unreleased]
 
+### Fixed
+
+- Initialization of Long Stillness Threshold (CU-860r11fng).
+
 ## [9.4.0] - 2023-05-23
 
 ### Changed

--- a/firmware/README.md
+++ b/firmware/README.md
@@ -517,9 +517,13 @@ Debug Message
 **Event Data**
 
 1. state: the current state the machine is in
-2. door_status: the current door status byte
-3. INS_val: the current filtered inPhase value from the INS radar
-4. timer_status: if the current state uses a timer, this contains the time in milliseconds that the timer has counted up to thus far. If the current state does not contain a timer, this is set to 0.
+1. door_status: the current door status byte
+1. INS_val: the current filtered inPhase value from the INS radar
+1. INS_threshold: the current threshold that we compare the INS_val against
+1. timer_status: if the current state uses a timer, this contains the time in milliseconds that the timer has counted up to thus far. If the current state does not contain a timer, this is set to 0.
+1. initial_timer: the initial timer value that the initial state compares against
+1. duration_timer: the duration timer value that the duration and stillness states compare against
+1. stillness_timer: the stillness timer value that the stillness state compares against
 
 ### **Debugging**
 

--- a/firmware/boron-ins-fsm/src/stateMachine.cpp
+++ b/firmware/boron-ins-fsm/src/stateMachine.cpp
@@ -86,8 +86,10 @@ void initializeStateMachineConsts() {
     Log.info("state machine constant State3MaxLongStillnessTime flag is 0x%04X", initializeState3MaxLongStillenssTimeFlag);
 
     if (initializeState3MaxLongStillenssTimeFlag != INITIALIZE_STATE3_MAX_LONG_STILLNESS_TIME_FLAG) {
-        EEPROM.put(ADDR_STATE3_MAX_LONG_STILLNESS_TIME,
-                   state3_max_stillness_time);  // By default, we use the same value for max_stillness_time and max_long_stillness_time
+        // By default, we use the same value for max_stillness_time and max_long_stillness_time
+        EEPROM.put(ADDR_STATE3_MAX_LONG_STILLNESS_TIME, state3_max_stillness_time);
+        state3_max_long_stillness_time = state3_max_stillness_time;
+
         initializeState3MaxLongStillenssTimeFlag = INITIALIZE_STATE3_MAX_LONG_STILLNESS_TIME_FLAG;
         EEPROM.put(ADDR_INITIALIZE_STATE3_MAX_LONG_STILLNESS_TIME_FLAG, initializeState3MaxLongStillenssTimeFlag);
         Log.info("State machine constant State3MaxLongStillnessTime was written to flash on bootup.");
@@ -158,7 +160,7 @@ void state1_15sCountdown() {
 
     // do stuff in the state
     digitalWrite(D2, HIGH);
-    Log.info("You are in state 1, 15s countdown: Door status, iAverage, timer = 0x%02X, %f, %ld", checkDoor.doorStatus, checkINS.iAverage,
+    Log.info("You are in state 1, initial countdown: Door status, iAverage, timer = 0x%02X, %f, %ld", checkDoor.doorStatus, checkINS.iAverage,
              (millis() - state1_timer));
     publishDebugMessage(1, checkDoor.doorStatus, checkINS.iAverage, (millis() - state1_timer));
 
@@ -310,8 +312,10 @@ void publishDebugMessage(int state, unsigned char doorStatus, float INSValue, un
     if (stateMachineDebugFlag && (millis() - lastDebugPublish) > DEBUG_PUBLISH_INTERVAL) {
         // from particle docs, max length of publish is 622 chars, I am assuming this includes null char
         char debugMessage[622];
-        snprintf(debugMessage, sizeof(debugMessage), "{\"state\":\"%d\", \"door_status\":\"0x%02X\", \"INS_val\":\"%f\", \"timer_status\":\"%lu\"}",
-                 state, doorStatus, INSValue, timer);
+        snprintf(debugMessage, sizeof(debugMessage),
+                 "{\"state\":\"%d\", \"door_status\":\"0x%02X\", \"INS_val\":\"%f\", \"INS_threshold\":\"%lu\", \"timer_status\":\"%lu\", "
+                 "\"initial_timer\":\"%lu\", \"duration_timer\":\"%lu\", \"stillness_timer\":\"%lu\"}",
+                 state, doorStatus, INSValue, ins_threshold, timer, state1_max_time, state2_max_duration, *max_stillness_time);
         Particle.publish("Debug Message", debugMessage, PRIVATE);
         lastDebugPublish = millis();
     }


### PR DESCRIPTION
- On the very first initialization of v9.4.0, the Long Stillness Timer value in EEPROM was begin set correctly to the current value of the previously-only Stillness Timer. But then that value wasn't being copied into the variable that was used in the State Machien to determine whether the threshold had been hit *doh*. So added that in
- And add more information to the debug mode messages

## Test Plan
- [x] Reproduce the problem on my local Sensor: without making any other changes, comment out the if-else statement in `stateMachine.cpp` so that the state3_max_long_stillness initialization part always happens
   - [x] Set my Short Stillness Timer = 15 and Long Stillness Timer = 30, then restart the Sensor. Turn on debug mode. See that the stillness_timer value is 15000 for the first Stillness Alert and then 120000 for the subsequent Stillness alerts
   - [x] Set the Long Stillness Timer = 30. See that the stillness_timer value is 15000 for the  first Stillness Alert and then 30000 for the subsequent Stillness Alerts
- [x] Fixed initialization on my local Sensor: make the changes in this PR but also comment out the if-else statement in `stateMachine.cpp` so that the state3_max_long_stillness initialization part always happens
   - [x] Set my Short Stillness Timer = 15 and Long Stillness Timer = 30, then restart the Sensor. Turn on debug mode. See that the stillness_timer value is 15000 for the first Stillness Alert and then 15000 for the subsequent Stillness alerts (to simulate when there was only the Short Stillness Timer) and that echoing the Long Stillness Timer returns 15
   - [x] Set the Long Stillness Timer = 30. See that the stillness_timer value is 15000 for the  first Stillness Alert and then 30000 for the subsequent Stillness Alerts
- [x] Double-check non-initialization case: make changes in this PR without anything commented out. On my Sensor, this means that I'll end up in the `else` case where it will read the Short and Long Stillness Timers from EEPROM.
   - [x] Set my Short Stillness Timer = 15 and Long Stillness Timer = 30, then restart the Sensor. Turn on debug mode. See that the stillness_timer value is 15000 for the first Stillness Alert and then 30000 for the subsequent Stillness alerts and that echoing the Long Stillness Timer returns 30