### PR TITLE
Add auto-off for debug messages (CU-860r0z9zb)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ the code was deployed.
 
 ## [Unreleased]
 
+### Added
+
+- Auto-shut off for debug publishes after 8 hours (CU-860r0z9zb).
+
 ## [9.5.0] - 2023-06-02
 
 ### Fixed

--- a/firmware/README.md
+++ b/firmware/README.md
@@ -206,11 +206,19 @@ The length of time defaults to 2 minutes. It is defined in milliseconds, so the 
 
 ### DEBUG_PUBLISH_INTERVAL
 
-This is defined via a macro in the stateMachine.h header file.
+This is defined via a macro in the debugFlags.h header file.
 
 It is the length of time between publishes of debug messages to the cloud. (Debug publishes are turned on and off via console function, see section on console functions below).
 
 The debug interval defaults to 1.5 seconds. It is defined in milliseconds, so the actual macro definition will be 1500 in code.
+
+### DEBUG_AUTO_OFF_THRESHOLD
+
+This is defined via a macro in the debugFlags.h header file.
+
+It is the maximum length of time to publish debug messages to the cloud. (Debug publishes are turned on via console function, see section on console functions below).
+
+The auto-off threshold is set to 8 hours (i.e. a standard work day). It is defined in milliseconds, so the actual macro definition will be 8 \* 60 \* 60 \* 1000 = 28800000 in code.
 
 ### SM_HEARTBEAT_INTERVAL
 
@@ -374,17 +382,17 @@ The default level is set to 60. This is based on the radar testing documented [h
 
 **Description:**
 
-Use this console function to turn cloud publishes of state machine debugging values on and off. Note the firmware defaults to off. When on, the debug publishes occur approximately every 1.5 seconds, so be mindful of Particle data limits when using this feature.
+Use this console function to turn cloud publishes of state machine debugging values on and off. Note the firmware defaults to off. When on, the debug publishes occur approximately every 1.5 seconds for a maximum of 8 hours, so be mindful of Particle data limits when using this feature.
 
 **Argument(s):**
 
 1. Enter 1 to turn publishes on
 2. Enter 0 to turn publishes off
+3. e - this is short for echo, and will echo the current value
 
 **Return(s):**
 
-- 0 if 0 is entered
-- 1 if 1 is entered
+- The current integer value (0 or 1)
 - -1: when bad data is entered
 
 ### **im21_door_id_set(String)**

--- a/firmware/boron-ins-fsm/src/consoleFunctions.cpp
+++ b/firmware/boron-ins-fsm/src/consoleFunctions.cpp
@@ -14,6 +14,7 @@
  */
 #include "Particle.h"
 #include "consoleFunctions.h"
+#include "debugFlags.h"
 #include "flashAddresses.h"
 #include "stateMachine.h"
 #include "imDoorSensor.h"
@@ -69,6 +70,7 @@ int toggle_debugging_publishes(String command) {
     }
     else if (*holder == '1') {
         stateMachineDebugFlag = true;
+        debugFlagTurnedOnAt = millis();
         returnFlag = 1;
     }
     else {

--- a/firmware/boron-ins-fsm/src/debugFlags.cpp
+++ b/firmware/boron-ins-fsm/src/debugFlags.cpp
@@ -1,0 +1,8 @@
+#include "debugFlags.h"
+
+// define global variables so they are allocated in memory
+unsigned long debugFlagTurnedOnAt;
+
+// inialize constants to sensible defaults. This will be overwritten
+bool stateMachineDebugFlag = false;
+unsigned long lastDebugPublish = 0;

--- a/firmware/boron-ins-fsm/src/debugFlags.h
+++ b/firmware/boron-ins-fsm/src/debugFlags.h
@@ -1,6 +1,19 @@
 #ifndef DEBUG_FLAGS_H
 #define DEBUG_FLAGS_H
 
+// Length of time between debug publishes
+#define DEBUG_PUBLISH_INTERVAL 1500  // ms
+
+// Max length of time to publish debug messages
+#define DEBUG_AUTO_OFF_THRESHOLD 28800000  // ms = 8 hours
+
+// Whether or not to publish debug messages
 extern bool stateMachineDebugFlag;
+
+// The value of millis() at the most recent time the debug publishes were turned on
+extern unsigned long debugFlagTurnedOnAt;
+
+// The value of millis() at the time of the most recent debug publish
+extern unsigned long lastDebugPublish;
 
 #endif

--- a/firmware/boron-ins-fsm/src/stateMachine.h
+++ b/firmware/boron-ins-fsm/src/stateMachine.h
@@ -20,11 +20,14 @@
 #define STATE2_MAX_DURATION       1200000  // ms = 20 min
 #define STATE3_MAX_STILLNESS_TIME 120000   // ms = 2 minutes
 
-// length of time between debug publishes
-#define DEBUG_PUBLISH_INTERVAL  1500    // ms
-#define SM_HEARTBEAT_INTERVAL   660000  // ms = 11 min
-#define DEVICE_RESET_THRESHOLD  540000  // ms = 9 min
-#define HEARTBEAT_STATES_CUTOFF 603     // = 622 - 17 (max length of sub state array) - 2 (length of closing brackets)
+// How often to publish Heartbeat messages
+#define SM_HEARTBEAT_INTERVAL 660000  // ms = 11 min
+
+// Attempt to minimize the time between a restart and the first Heartbeat message
+#define DEVICE_RESET_THRESHOLD 540000  // ms = 9 min
+
+// How many characters can be used to send the states array in the Heartbeat messages
+#define HEARTBEAT_STATES_CUTOFF 603  // = 622 - 17 (max length of sub state array) - 2 (length of closing brackets)
 
 // Restricts heartbeat to being published once instead of 3 times from the 3 IM Door Sensor broadcasts
 #define HEARTBEAT_PUBLISH_DELAY 1000  // ms = 1 sec
@@ -68,8 +71,5 @@ extern unsigned long state1_max_time;
 extern unsigned long state2_max_duration;
 extern unsigned long state3_max_stillness_time;
 extern unsigned long state3_max_long_stillness_time;
-
-// flag to turn debugging on and off
-extern bool stateMachineDebugFlag;
 
 #endif

--- a/firmware/boron-ins-fsm/test/base.h
+++ b/firmware/boron-ins-fsm/test/base.h
@@ -29,6 +29,7 @@ MockLogger Log;
 MockBLE BLE;
 
 bool stateMachineDebugFlag;
+unsigned long debugFlagTurnedOnAt;
 long unsigned state1_max_time;
 long unsigned state2_max_duration;
 long unsigned state3_max_stillness_time;


### PR DESCRIPTION
- Debug publishes will automatically turn off after 8 hours so that we don't end up accidentally leaving it on for days at a time, using up all our Particle data operations
- Removed the `stateMachineDebugFlag` from stateMachine.h and just included `debugFlags.h` instead. That will reduce the repetition
- Moved `lastDebugPublish` into `debugFlags.h` to keep all the debug-related things together and to clarify that it is a global variable
- Moved the `DEBUG_PUBLISH_INTERVAL` constant into `debugFlags.h` also to keep all the debug-related things together

## Test Plan
- [x] Change values of `DEBUG_PUBLISH_INTERVAL` and `DEBUG_AUTO_OFF_THRESHOLD` to something easy to test in real time and deploy to real Sensor (see version 9.5.6)
- [x] When Sensor first turns on
   - [x] No debug messages
- [x] Turn on the debug messages
   - [x] Before the `DEBUG_AUTO_OFF_THRESHOLD`
      - [x] See a debug message every `DEBUG_PUBLISH_INTERVAL` ms
      - [x] See state transition messages
      - [x] When you echo the debug publish, get back `1`
   - [x] After the `DEBUG_AUTO_OFF_THRESHOLD`
      - [x] No debug messages
      - [x] No state transition messages
      - [x] When you echo the debug publish, get back `0`
- [x] If you turn debug mode on again while it's already on, then it doesn't turn off until `DEBUG_AUTO_OFF_THRESHOLD` after the most recent time that you turned it on