### PR TITLE
Add CORS configuration to Express Proxy Middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ the code was deployed.
 
 ## [Unreleased]
 
+### Added
+
+- CORS configuration to Express Proxy Middleware.
+
 ### Removed
 
 - Unused environment variable `RADAR_WINDOW_SIZE_SECONDS`.

--- a/server/index.js
+++ b/server/index.js
@@ -32,13 +32,23 @@ const intervalToCheckAlerts = parseInt(helpers.getEnvVar('INTERVAL_TO_CHECK_ALER
 
 // Configure and add ClickUp API proxy
 // Ref: https://github.com/chimurai/http-proxy-middleware/blob/master/examples/express/index.js
+
+/* eslint-disable no-param-reassign */
 const jsonPlaceholderProxy = createProxyMiddleware({
   target: 'https://api.clickup.com',
   changeOrigin: true,
   secure: false,
   logLevel: 'warn',
   pathRewrite: { '^/clickupapi': '/api' },
+  onProxyRes: proxyRes => {
+    proxyRes.headers['Access-Control-Allow-Origin'] = '*'
+    proxyRes.headers['Access-Control-Allow-Headers'] =
+      'DNT,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization'
+    proxyRes.headers['Access-Control-Allow-Methods'] = 'GET, PUT, POST, DELETE, PATCH, OPTIONS'
+    proxyRes.headers['Access-Control-Max-Age'] = '1728000'
+  },
 })
+/* eslint-enable no-param-reassign */
 app.use('/clickupapi', jsonPlaceholderProxy)
 
 // Body Parser Middleware


### PR DESCRIPTION
- These CORS options were being added by our Kubenetes nginx ingress, but since we aren't going to be using Kubernetes anymore, it now needs to be done by Express
- The defaults used by Kubenetes are explained here: https://github.com/kubernetes/ingress-nginx/blob/main/docs/user-guide/nginx-configuration/annotations.md#enable-cors
- This solution came from https://stackoverflow.com/questions/32659139/how-to-overcome-access-control-allow-origin-error-when-client-talks-to-server#answer-32748086

## Test plan
- [x] Deploy to Dev on AWS
   - [x] Login to ClickUp using the AWS Dev endpoint
   - [x] Run smoke tests on AWS Dev endpoint
- [x] Deploy to Dev on Kubernetes
   - [x] Login to ClickUp using the Kubernetes Dev endpoint
   - [x] Run smoke tests on Kubernetes endpoint