### PR TITLE
Sentry log for sensor frequently missing door events (CU-860rk8v2a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,18 +9,13 @@ Please note that the date associated with a release is the date the code
 was committed to the `production` branch. This is not necessarily the date that
 the code was deployed.
 
-## [9.6.0] - 2023-09-12
-
-### Added
-
-- "doorMissedFrequently" field to JSON data submitted by brave sensors that is sent to /api/heartbeat (CU-860rk8v2a)
-- Sentry log in the case that doorMissedFrequently is true in posted data from brave sensor (CU-860rk8v2a)
-
 ## [Unreleased]
 
 ### Added
 
 - CORS configuration to Express Proxy Middleware.
+- "doorMissedFrequently" field to JSON data submitted by brave sensors that is sent to /api/heartbeat (CU-860rk8v2a)
+- Sentry log in the case that doorMissedFrequently is true in posted data from brave sensor (CU-860rk8v2a)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ Please note that the date associated with a release is the date the code
 was committed to the `production` branch. This is not necessarily the date that
 the code was deployed.
 
+## [9.6.0] - 2023-09-12
+
+### Added
+
+- "doorMissedFrequently" field to JSON data submitted by brave sensors that is sent to /api/heartbeat (CU-860rk8v2a)
+- Sentry log in the case that doorMissedFrequently is true in posted data from brave sensor (CU-860rk8v2a)
+
 ## [Unreleased]
 
 ### Added

--- a/firmware/boron-ins-fsm/src/BraveSensorProductionFirmware.ino
+++ b/firmware/boron-ins-fsm/src/BraveSensorProductionFirmware.ino
@@ -11,7 +11,7 @@
 #include "tpl5010watchdog.h"
 
 #define DEBUG_LEVEL            LOG_LEVEL_INFO
-#define BRAVE_FIRMWARE_VERSION 9060   // see versioning notes in the readme
+#define BRAVE_FIRMWARE_VERSION 9061   // see versioning notes in the readme
 #define BRAVE_PRODUCT_ID       14807  // 14807 = beta units, 15479 = production units
 
 PRODUCT_ID(BRAVE_PRODUCT_ID);             // you get this number off the particle console, see readme for instructions

--- a/firmware/boron-ins-fsm/src/BraveSensorProductionFirmware.ino
+++ b/firmware/boron-ins-fsm/src/BraveSensorProductionFirmware.ino
@@ -11,7 +11,7 @@
 #include "tpl5010watchdog.h"
 
 #define DEBUG_LEVEL            LOG_LEVEL_INFO
-#define BRAVE_FIRMWARE_VERSION 9061   // see versioning notes in the readme
+#define BRAVE_FIRMWARE_VERSION 9060   // see versioning notes in the readme
 #define BRAVE_PRODUCT_ID       14807  // 14807 = beta units, 15479 = production units
 
 PRODUCT_ID(BRAVE_PRODUCT_ID);             // you get this number off the particle console, see readme for instructions

--- a/firmware/boron-ins-fsm/src/stateMachine.cpp
+++ b/firmware/boron-ins-fsm/src/stateMachine.cpp
@@ -373,14 +373,14 @@ const char *resetReasonString(int resetReason) {
 
 void getHeartbeat() {
     // constants (NOTE: should move to a global constants section?)
-    const unsigned int missedDoorEventTrackN = 3; // track the last 3 heartbeats
-    const unsigned int missedDoorEventMax    = 1; // can miss messages in max 1 of N heartbeats
+    const unsigned int missedDoorEventTrackN = 3;  // track the last 3 heartbeats
+    const unsigned int missedDoorEventMax = 1;     // can miss messages in max 1 of N heartbeats
 
     // statics
     static unsigned long lastHeartbeatPublish = 0;
-    static std::queue<bool> missedDoorEventQueue; // queue storing whether the last N heartbeats missed door events
-    static unsigned int missedDoorEventAmnt; // number of the last N heartbeats that missed door events
-    	// (horizontal sum of missedDoorEventQueue)
+    static std::queue<bool> missedDoorEventQueue;  // queue storing whether the last N heartbeats missed door events
+    static unsigned int missedDoorEventAmnt = 0;   // number of the last N heartbeats that missed door events
+                                                   // (horizontal sum of missedDoorEventQueue)
 
     // 1st "if condition" is so that the boron publishes a heartbeat on startup
     // 2nd "if condition" is so that the boron publishes a heartbeat, when the doorMessageReceivedFlag is true.
@@ -395,13 +395,13 @@ void getHeartbeat() {
         writer.beginObject();
 
         if (missedDoorEventQueue.size() > missedDoorEventTrackN) {
-            if (missedDoorEventQueue.front())
-	        missedDoorEventAmnt--; // oldest value did miss; subtract it from the current amount
+            // if oldest value did miss; subtract 1 from the current amount
+            if (missedDoorEventQueue.front()) missedDoorEventAmnt--;
             missedDoorEventQueue.pop();
         }
         bool didMiss = missedDoorEventCount > 0;
-        missedDoorEventAmnt += (int)didMiss;
-        missedDoorEventQueue.push(didMiss); // enqueue whether this heartbeat did miss
+        missedDoorEventAmnt += (int)didMiss;  // if did miss; add 1 to the current amount
+        missedDoorEventQueue.push(didMiss);   // enqueue whether this heartbeat did miss
         // logs whether or not sensor is frequently missing door events
         writer.name("doorMissedFreq").value(missedDoorEventAmnt > missedDoorEventMax);
 

--- a/firmware/boron-ins-fsm/src/stateMachine.cpp
+++ b/firmware/boron-ins-fsm/src/stateMachine.cpp
@@ -373,8 +373,6 @@ const char *resetReasonString(int resetReason) {
 
 void getHeartbeat() {
     static unsigned long lastHeartbeatPublish = 0;
-    static unsigned int didMissQueueSum = 0;
-    static std::queue<bool> didMissQueue;
 
     // 1st "if condition" is so that the boron publishes a heartbeat on startup
     // 2nd "if condition" is so that the boron publishes a heartbeat, when the doorMessageReceivedFlag is true.
@@ -383,6 +381,8 @@ void getHeartbeat() {
     // 3rd "if condition" is true only if a heartbeat hasnt been published in the last SM_HEARTBEAT_INTERVAL
     if (lastHeartbeatPublish == 0 || (doorMessageReceivedFlag && ((millis() - doorHeartbeatReceived) >= HEARTBEAT_PUBLISH_DELAY)) ||
         (millis() - lastHeartbeatPublish) > SM_HEARTBEAT_INTERVAL) {
+        static unsigned int didMissQueueSum = 0;
+        static std::queue<bool> didMissQueue;
         // from particle docs, max length of publish is 622 chars, I am assuming this includes null char
         char heartbeatMessage[622] = {0};
         JSONBufferWriter writer(heartbeatMessage, sizeof(heartbeatMessage) - 1);

--- a/firmware/boron-ins-fsm/src/stateMachine.h
+++ b/firmware/boron-ins-fsm/src/stateMachine.h
@@ -23,6 +23,9 @@
 // How often to publish Heartbeat messages
 #define SM_HEARTBEAT_INTERVAL 660000  // ms = 11 min
 
+#define SM_HEARTBEAT_DID_MISS_QUEUE_SIZE 3  // keep track of whether the last 3 heartbeats did miss events
+#define SM_HEARTBEAT_DID_MISS_THRESHOLD  1  // threshold of the last N heartbeats that can miss events
+
 // Attempt to minimize the time between a restart and the first Heartbeat message
 #define DEVICE_RESET_THRESHOLD 540000  // ms = 9 min
 
@@ -59,6 +62,9 @@ typedef void (*StateHandler)();
 
 // declaring the state handler pointer as extern so .ino file can use it
 extern StateHandler stateHandler;
+
+// time in ms since start of device of last heartbeat publish
+extern unsigned long lastHeartbeatPublish;
 
 // these are the timers that are zero'ed by millis()
 extern unsigned long state1_timer;

--- a/firmware/boron-ins-fsm/src/stateMachine.h
+++ b/firmware/boron-ins-fsm/src/stateMachine.h
@@ -63,9 +63,6 @@ typedef void (*StateHandler)();
 // declaring the state handler pointer as extern so .ino file can use it
 extern StateHandler stateHandler;
 
-// time in ms since start of device of last heartbeat publish
-extern unsigned long lastHeartbeatPublish;
-
 // these are the timers that are zero'ed by millis()
 extern unsigned long state1_timer;
 extern unsigned long state2_duration_timer;

--- a/server/vitals.js
+++ b/server/vitals.js
@@ -232,6 +232,7 @@ async function handleHeartbeat(req, res) {
         } else {
           const message = JSON.parse(req.body.data)
           const doorMissedMessagesCount = message.doorMissedMsg
+          const doorMissedFreq = message.doorMissedFreq
           const resetReason = message.resetReason
           const stateTransitionsArray = message.states.map(convertStateArrayToObject)
           const mostRecentSensorVitals = await db.getMostRecentSensorsVitalWithLocationid(location.locationid)
@@ -265,6 +266,10 @@ async function handleHeartbeat(req, res) {
             doorLastSeenAt = DateTime.fromJSDate(currentDbTime).minus(message.doorLastMessage).toJSDate()
             isTamperedFlag = message.doorTampered
             doorLowBatteryFlag = message.doorLowBatt
+          }
+
+          if (doorMissedFreq) {
+            helpers.logSentry(`Sensor ${location.displayName} for client ${location.client.displayName} is frequently missing door events.`)
           }
 
           if (doorLowBatteryFlag) {

--- a/server/vitals.js
+++ b/server/vitals.js
@@ -232,7 +232,7 @@ async function handleHeartbeat(req, res) {
         } else {
           const message = JSON.parse(req.body.data)
           const doorMissedMessagesCount = message.doorMissedMsg
-          const doorMissedFreq = message.doorMissedFreq
+          const doorMissedFrequently = message.doorMissedFrequently
           const resetReason = message.resetReason
           const stateTransitionsArray = message.states.map(convertStateArrayToObject)
           const mostRecentSensorVitals = await db.getMostRecentSensorsVitalWithLocationid(location.locationid)
@@ -268,8 +268,8 @@ async function handleHeartbeat(req, res) {
             doorLowBatteryFlag = message.doorLowBatt
           }
 
-          if (doorMissedFreq) {
-            helpers.logSentry(`Sensor ${location.displayName} for client ${location.client.displayName} is frequently missing door events.`)
+          if (doorMissedFrequently) {
+            helpers.logSentry(`Sensor is frequently missing door events at ${location.locationid}`)
           }
 
           if (doorLowBatteryFlag) {


### PR DESCRIPTION
The firmware keeps track of the previous 3 heartbeats and whether or not they missed door events. If >1 of the last 3 heartbeats missed door events, `doorMissedFrequently` will be set to true in the JSON data published to Particle.

`vitals.js` handles `/api/heartbeat`, and upon receiving this data from the sensor, will check if `doorMissedFrequently` is set to true; if yes, a Sentry log will be sent.

Test plan:
- [x] Tested that firmware detects >1 of 3 previous heartbeats missed door events (used Serial monitor and watched logs)
- [x] Wrote test cases in `test/integration/vitalsTest/handleHeartbeatTest.js` to make sure server logs to Sentry if `doorMissedFrequently` is true.