### PR TITLE
Reset Stillness Timer (CU-860rbtg4k)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ the code was deployed.
 
 - Cloud function to reset the current Stillness Timer (CU-860rbtg4k).
 
+### Changed
+
+- Reset Stillness Timer when a Responder responds (CU-860rbtg4k).
+
 ## [9.8.0] - 2023-09-29
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ the code was deployed.
 
 ## [Unreleased]
 
+### Added
+
+- Cloud function to reset the current Stillness Timer (CU-860rbtg4k).
+
 ## [9.8.0] - 2023-09-29
 
 ### Security

--- a/firmware/README.md
+++ b/firmware/README.md
@@ -433,6 +433,20 @@ Use this console function to force the boron to reset. Useful for development an
 - Nothing if 1 is entered, but does send a message to the particle console to warn about particle's future failed to call message
 - -1 - when bad data is entered
 
+### **reset_stillness_timer_for_alerting_session(String)**
+
+**Description:**
+
+Use this console function to reset the current stillness timer to the current time if and only if the current session has sent at least one alert. This acts to extend the period of time before subsequent Stillness Alerts.
+
+**Argument(s):**
+
+1. Enter any String
+
+**Return(s):**
+
+- The length of the stillness timer before it was reset, converted from a ` long` to an `int`.
+
 ## State Machine Published Messages
 
 ### **Stillness Alert**

--- a/firmware/boron-ins-fsm/src/consoleFunctions.cpp
+++ b/firmware/boron-ins-fsm/src/consoleFunctions.cpp
@@ -29,6 +29,7 @@ void setupConsoleFunctions() {
     Particle.function("Change_Long_Stillness_Timer", long_stillness_timer_set);
     Particle.function("Change_INS_Threshold", ins_threshold_set);
     Particle.function("Change_IM21_Door_ID", im21_door_id_set);
+    Particle.function("Reset_Stillness_Timer_For_Alerting_Session", reset_stillness_timer_for_alerting_session);
 }
 
 bool isValidIM21Id(String input) {
@@ -183,6 +184,18 @@ int stillness_timer_set(String input) {
     }
 
     return returnFlag;
+}
+
+// returns the previous length of the stillness timer
+int reset_stillness_timer_for_alerting_session(String input) {
+    int returnValue = -1;
+
+    if (hasDurationAlertBeenSent || hasStillnessAlertBeenSent) {
+        returnValue = (int)(millis() - state3_stillness_timer);
+        state3_stillness_timer = millis();
+    }
+
+    return returnValue;
 }
 
 // returns long stillness timer length if valid input is given, otherwise returns -1

--- a/firmware/boron-ins-fsm/src/consoleFunctions.h
+++ b/firmware/boron-ins-fsm/src/consoleFunctions.h
@@ -24,5 +24,6 @@ int ins_threshold_set(String);
 int im21_door_id_set(String);
 int toggle_debugging_publishes(String);
 int force_reset(String);
+int reset_stillness_timer_for_alerting_session(String);
 
 #endif

--- a/firmware/boron-ins-fsm/src/stateMachine.cpp
+++ b/firmware/boron-ins-fsm/src/stateMachine.cpp
@@ -26,8 +26,9 @@ unsigned long state3_max_stillness_time = STATE3_MAX_STILLNESS_TIME;
 unsigned long state3_max_long_stillness_time =
     STATE3_MAX_STILLNESS_TIME;  // By default, we use the same value for max_stillness_time and max_long_stillness_time
 int resetReason = System.resetReason();
-// record whether a duration alert has been sent within the same session
+// record whether an alert has been sent within the same session
 bool hasDurationAlertBeenSent;
+bool hasStillnessAlertBeenSent;
 // which max stillness time are we currently comparing against
 // using pointers so that the value pointed to be max_stillness_time will be the correct values of state3_max_stillness_time or
 // state3_max_long_stillness_time even if they change due to a console function call during the session
@@ -49,7 +50,10 @@ void setupStateMachine() {
     stateMachineDebugFlag = 0;
 
     // default to no duration alert sent
-    hasDurationAlertBeenSent = 0;
+    hasDurationAlertBeenSent = false;
+
+    // default to no stillness alert sent
+    hasStillnessAlertBeenSent = false;
 }
 
 void initializeStateMachineConsts() {
@@ -113,8 +117,9 @@ void state0_idle() {
     checkDoor = checkIM();
     // this returns 0.0 if the INS has no new data to transmit
     checkINS = checkINS3331();
-    // session is over in idle state, so reset the whether duration alert has been sent flag
-    hasDurationAlertBeenSent = 0;
+    // session is over in idle state, so reset the whether alert has been sent flags
+    hasDurationAlertBeenSent = false;
+    hasStillnessAlertBeenSent = false;
     // set to compare against the shorter stillness threshold
     max_stillness_time = &state3_max_stillness_time;
 
@@ -226,7 +231,7 @@ void state2_duration() {
         saveStateChangeOrAlert(2, 4);
         Log.error("Duration Alert!!");
         Particle.publish("Duration Alert", "duration alert", PRIVATE);
-        hasDurationAlertBeenSent = 1;  // a duration alert has been sent, so do not send another one
+        hasDurationAlertBeenSent = true;
         stateHandler = state2_duration;
     }
     else {
@@ -272,6 +277,7 @@ void state3_stillness() {
         saveStateChangeOrAlert(3, 5);
         Log.error("Stillness Alert!!");
         Particle.publish("Stillness Alert", "stillness alert!!!", PRIVATE);
+        hasStillnessAlertBeenSent = true;
         state3_stillness_timer = millis();                     // reset the stillness timer
         max_stillness_time = &state3_max_long_stillness_time;  // set to compare against the longer stillness threshold for the rest of this session
         stateHandler = state3_stillness;
@@ -282,7 +288,7 @@ void state3_stillness() {
         saveStateChangeOrAlert(3, 4);
         Log.error("Duration Alert!!");
         Particle.publish("Duration Alert", "duration alert", PRIVATE);
-        hasDurationAlertBeenSent = 1;  // a duration alert has been sent, so do not send another one
+        hasDurationAlertBeenSent = true;
         stateHandler = state3_stillness;
     }
     else {

--- a/firmware/boron-ins-fsm/src/stateMachine.h
+++ b/firmware/boron-ins-fsm/src/stateMachine.h
@@ -75,4 +75,8 @@ extern unsigned long state2_max_duration;
 extern unsigned long state3_max_stillness_time;
 extern unsigned long state3_max_long_stillness_time;
 
+// whether or not the current session has sent alerts
+extern bool hasDurationAlertBeenSent;
+extern bool hasStillnessAlertBeenSent;
+
 #endif

--- a/server/BraveAlerterConfigurator.js
+++ b/server/BraveAlerterConfigurator.js
@@ -23,9 +23,7 @@ class BraveAlerterConfigurator {
   }
 
   async createAlertSessionFromSession(session) {
-    const location = await db.getLocationData(session.locationid)
-
-    const client = location.client
+    const client = session.location.client
     const alertSession = new AlertSession(
       session.id,
       session.chatbotState,
@@ -109,8 +107,7 @@ class BraveAlerterConfigurator {
           }
 
           if (alertSession.incidentCategoryKey) {
-            const location = await db.getLocationData(session.locationid, pgClient)
-            session.incidentCategory = location.client.incidentCategories[parseInt(alertSession.incidentCategoryKey, 10) - 1]
+            session.incidentCategory = session.location.client.incidentCategories[parseInt(alertSession.incidentCategoryKey, 10) - 1]
           }
 
           if (alertSession.alertState === CHATBOT_STATE.WAITING_FOR_CATEGORY && session.respondedAt === null) {

--- a/server/BraveAlerterConfigurator.js
+++ b/server/BraveAlerterConfigurator.js
@@ -5,6 +5,7 @@ const { t } = require('i18next')
 // In-house dependencies
 const { ActiveAlert, BraveAlerter, AlertSession, CHATBOT_STATE, helpers, HistoricAlert, Location, SYSTEM } = require('brave-alert-lib')
 const db = require('./db/db')
+const particleFunctions = require('./particleFunctions')
 
 class BraveAlerterConfigurator {
   createBraveAlerter() {
@@ -111,6 +112,16 @@ class BraveAlerterConfigurator {
           }
 
           if (alertSession.alertState === CHATBOT_STATE.WAITING_FOR_CATEGORY && session.respondedAt === null) {
+            const oldStillnessTimer = await particleFunctions.resetStillnessTimer(
+              session.location.radarCoreId,
+              helpers.getEnvVar('PARTICLE_PRODUCT_GROUP'),
+            )
+            if (oldStillnessTimer > -1) {
+              helpers.log(`Reset stillness timer for ${session.location.locationid} from ${oldStillnessTimer} to 0`)
+            } else {
+              helpers.log(`Did not reset stillness timer for ${session.location.locationid}`)
+            }
+
             session.respondedAt = await db.getCurrentTime(pgClient)
           }
 

--- a/server/Session.js
+++ b/server/Session.js
@@ -1,7 +1,6 @@
 class Session {
-  constructor(id, locationid, chatbotState, alertType, createdAt, updatedAt, incidentCategory, respondedAt, respondedByPhoneNumber) {
+  constructor(id, chatbotState, alertType, createdAt, updatedAt, incidentCategory, respondedAt, respondedByPhoneNumber, location) {
     this.id = id
-    this.locationid = locationid
     this.chatbotState = chatbotState
     this.alertType = alertType
     this.createdAt = createdAt
@@ -9,6 +8,7 @@ class Session {
     this.incidentCategory = incidentCategory
     this.respondedAt = respondedAt
     this.respondedByPhoneNumber = respondedByPhoneNumber
+    this.location = location
   }
 }
 

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -27,7 +27,7 @@
         "lodash": "^4.17.21",
         "luxon": "^2.5.2",
         "mustache": "^3.2.1",
-        "particle-api-js": "^7.4.0",
+        "particle-api-js": "^10.0.0",
         "pg": "^8.2.0"
       },
       "devDependencies": {
@@ -1503,9 +1503,9 @@
       }
     },
     "node_modules/builtin-status-codes": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-2.0.0.tgz",
-      "integrity": "sha512-8KPx+JfZWi0K8L5sycIOA6/ZFZbaFKXDeUIXaqwUnhed1Ge1cB0wyq+bNDjKnL9AR2Uj3m/khkF6CDolsyMitA=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
+      "integrity": "sha512-HpGFw18DgFWlncDfjTa2rcQ4W88O1mC8e8yZ2AvQY5KDaktSTwo+KRf6nHK6FRI5FyRyb/5T6+TSxfP7QyGsmQ=="
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -1762,7 +1762,8 @@
     "node_modules/component-emitter": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
-      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
+      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
+      "dev": true
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -1837,7 +1838,8 @@
     "node_modules/cookiejar": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
-      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw=="
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true
     },
     "node_modules/core-js": {
       "version": "2.6.12",
@@ -2860,11 +2862,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
-    },
     "node_modules/extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
@@ -3062,7 +3059,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
       "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dev": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -4832,6 +4828,25 @@
         "isarray": "0.0.1"
       }
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/node-preload": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/node-preload/-/node-preload-0.2.1.tgz",
@@ -5268,66 +5283,19 @@
       }
     },
     "node_modules/particle-api-js": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/particle-api-js/-/particle-api-js-7.4.1.tgz",
-      "integrity": "sha512-ln1yYuwRmPrROQ95M5Kg4FyLXIVbupwQBU36nE2K8NqcSX46b+B+6GZjvKIRk2F8XKgtz2WjORc8rArRE0sJnA==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/particle-api-js/-/particle-api-js-10.0.0.tgz",
+      "integrity": "sha512-7GhLEVE8NOrNjde+2rf4b5rjPDMWSqMm/g5ri3OQv+NWLcC/Et6n1PkdcHjAGhbafeyvdHJExJrdU+xSmnkm7g==",
       "dependencies": {
         "babel-runtime": "^6.9.2",
-        "form-data": ">2.2.0",
-        "stream-http": "https://github.com/particle-iot/stream-http/archive/v2.2.1.tar.gz",
-        "superagent": "^3.6.0",
-        "superagent-prefix": "0.0.2"
-      }
-    },
-    "node_modules/particle-api-js/node_modules/debug": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-      "dependencies": {
-        "ms": "^2.1.1"
-      }
-    },
-    "node_modules/particle-api-js/node_modules/form-data": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
-      "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
+        "form-data": "^4.0.0",
+        "node-fetch": "^2.7.0",
+        "qs": "^6.11.2",
+        "stream-http": "^3.2.0"
       },
       "engines": {
-        "node": ">= 0.12"
-      }
-    },
-    "node_modules/particle-api-js/node_modules/formidable": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.6.tgz",
-      "integrity": "sha512-KcpbcpuLNOwrEjnbpMC0gS+X8ciDoZE1kkqzat4a8vrprf+s9pKNQ/QIwWfbfs4ltgmFl3MD177SNTkve3BwGQ==",
-      "deprecated": "Please upgrade to latest, formidable@v2 or formidable@v3! Check these notes: https://bit.ly/2ZEqIau",
-      "funding": {
-        "url": "https://ko-fi.com/tunnckoCore/commissions"
-      }
-    },
-    "node_modules/particle-api-js/node_modules/superagent": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.3.tgz",
-      "integrity": "sha512-GLQtLMCoEIK4eDv6OGtkOoSMt3D+oq0y3dsxMuYuDvaNUvuT8eFBuLmfR0iYYzHC1e8hpzC6ZsxbuP6DIalMFA==",
-      "deprecated": "Please upgrade to v7.0.2+ of superagent.  We have fixed numerous issues with streams, form-data, attach(), filesystem errors not bubbling up (ENOENT on attach()), and all tests are now passing.  See the releases tab for more information at <https://github.com/visionmedia/superagent/releases>.",
-      "dependencies": {
-        "component-emitter": "^1.2.0",
-        "cookiejar": "^2.1.0",
-        "debug": "^3.1.0",
-        "extend": "^3.0.0",
-        "form-data": "^2.3.1",
-        "formidable": "^1.2.0",
-        "methods": "^1.1.1",
-        "mime": "^1.4.1",
-        "qs": "^6.5.1",
-        "readable-stream": "^2.3.5"
-      },
-      "engines": {
-        "node": ">= 4.0"
+        "node": ">=12.x",
+        "npm": "8.x"
       }
     },
     "node_modules/path-exists": {
@@ -5680,11 +5648,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
-    },
     "node_modules/process-on-spawn": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/process-on-spawn/-/process-on-spawn-1.0.0.tgz",
@@ -5803,28 +5766,17 @@
       "dev": true
     },
     "node_modules/readable-stream": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
-    },
-    "node_modules/readable-stream/node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
-    },
-    "node_modules/readable-stream/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "node_modules/readdirp": {
       "version": "3.6.0",
@@ -6284,29 +6236,23 @@
       }
     },
     "node_modules/stream-http": {
-      "version": "2.2.1",
-      "resolved": "https://github.com/particle-iot/stream-http/archive/v2.2.1.tar.gz",
-      "integrity": "sha512-eiMmV7ssQY13N4JoAHkr9nWvq5TgbQp6VyeCA6/UGZjBSepFMhtfICRDNzkzPNY/NPJ/os0an1xExHISjfBkmg==",
-      "license": "MIT",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-3.2.0.tgz",
+      "integrity": "sha512-Oq1bLqisTyK3TSCXpPbT4sdeYNdmyZJv1LxpEm2vu1ZhK89kSE5YXwZc3cWk0MagGaKriBh9mCFbVGtO+vY29A==",
       "dependencies": {
-        "builtin-status-codes": "^2.0.0",
-        "inherits": "^2.0.1",
-        "to-arraybuffer": "^1.0.0",
-        "xtend": "^4.0.0"
+        "builtin-status-codes": "^3.0.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.6.0",
+        "xtend": "^4.0.2"
       }
     },
     "node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "dependencies": {
-        "safe-buffer": "~5.1.0"
+        "safe-buffer": "~5.2.0"
       }
-    },
-    "node_modules/string_decoder/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "node_modules/string-width": {
       "version": "4.2.3",
@@ -6455,11 +6401,6 @@
         "node": ">=6.4.0 <13 || >=14"
       }
     },
-    "node_modules/superagent-prefix": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/superagent-prefix/-/superagent-prefix-0.0.2.tgz",
-      "integrity": "sha512-LssjLYPklgE/ZlaowG+DZjSvXkiwyT47U3D1tvgDlAeG7w7ew5MowVXwepIt+yoVql2xQmgR/sJr2sivkRyN7g=="
-    },
     "node_modules/superagent/node_modules/mime": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
@@ -6553,11 +6494,6 @@
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
     },
-    "node_modules/to-arraybuffer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
-      "integrity": "sha512-okFlQcoGTi4LQBG/PgSYblw9VOyptsz2KJZqc6qtgGdes8VktzUQkj4BI2blit072iS8VODNcMA+tvnS9dnuMA=="
-    },
     "node_modules/to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
@@ -6585,6 +6521,11 @@
       "engines": {
         "node": ">=0.6"
       }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "node_modules/tsconfig-paths": {
       "version": "3.14.2",
@@ -6934,6 +6875,20 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {

--- a/server/package.json
+++ b/server/package.json
@@ -34,7 +34,7 @@
     "lodash": "^4.17.21",
     "luxon": "^2.5.2",
     "mustache": "^3.2.1",
-    "particle-api-js": "^7.4.0",
+    "particle-api-js": "^10.0.0",
     "pg": "^8.2.0"
   },
   "devDependencies": {

--- a/server/particleFunctions.js
+++ b/server/particleFunctions.js
@@ -1,0 +1,30 @@
+// Third-party dependencies
+const Particle = require('particle-api-js')
+
+// In-house depenencies
+const { helpers } = require('brave-alert-lib')
+
+const particle = new Particle()
+
+async function resetStillnessTimer(deviceId, productId) {
+  try {
+    const response = await particle.callFunction({
+      deviceId,
+      name: 'Reset_Stillness_Timer_For_Alerting_Session',
+      argument: '',
+      product: productId,
+      auth: helpers.getEnvVar('PARTICLE_ACCESS_TOKEN'),
+    })
+
+    // response.body.return_value should contain the old value of the Stillness Timer before it was reset
+    return response.body.return_value
+  } catch (err) {
+    helpers.log(`${err.errorDescription} : for device ${deviceId}`)
+  }
+
+  return -1
+}
+
+module.exports = {
+  resetStillnessTimer,
+}

--- a/server/test/unit/BraveAlerterConfiguratorTest/alertSessionChangedCallbackTest.js
+++ b/server/test/unit/BraveAlerterConfiguratorTest/alertSessionChangedCallbackTest.js
@@ -5,9 +5,10 @@ const sinon = require('sinon')
 const sinonChai = require('sinon-chai')
 
 // In-house dependencies
-const { AlertSession, CHATBOT_STATE, factories } = require('brave-alert-lib')
+const { AlertSession, CHATBOT_STATE, factories, helpers } = require('brave-alert-lib')
 const BraveAlerterConfigurator = require('../../../BraveAlerterConfigurator')
 const db = require('../../../db/db')
+const particleFunctions = require('../../../particleFunctions')
 const { locationFactory, sessionFactory } = require('../../../testingHelpers')
 
 // Configure Chai
@@ -72,6 +73,57 @@ describe('BraveAlerterConfigurator.js unit tests: alertSessionChangedCallback', 
     })
 
     expect(db.saveSession).to.be.calledWith(expectedSession, sandbox.any)
+  })
+
+  it('if given alertState WAITING_FOR_CATEGORY and it has not already been responded to should reset the stillness timer in the firmware state machine', async () => {
+    const sessionId = 'ca6e85b1-0a8c-4e1a-8d1e-7a35f838d7bc'
+    const newRespondedByPhoneNumber = '+18887774444'
+    sandbox.stub(db, 'getSessionWithSessionId').returns(sessionFactory({ id: sessionId, respondedAt: null, respondedByPhoneNumber: null }))
+    sandbox.stub(particleFunctions, 'resetStillnessTimer')
+
+    const braveAlerterConfigurator = new BraveAlerterConfigurator()
+    const braveAlerter = braveAlerterConfigurator.createBraveAlerter()
+    await braveAlerter.alertSessionChangedCallback(new AlertSession(sessionId, CHATBOT_STATE.WAITING_FOR_CATEGORY, newRespondedByPhoneNumber))
+
+    const expectedSession = sessionFactory({
+      id: sessionId,
+      chatbotState: CHATBOT_STATE.WAITING_FOR_CATEGORY,
+      respondedAt: this.testCurrentTime,
+      respondedByPhoneNumber: newRespondedByPhoneNumber,
+    })
+
+    expect(particleFunctions.resetStillnessTimer).to.be.calledWith(expectedSession.location.radarCoreId, helpers.getEnvVar('PARTICLE_PRODUCT_GROUP'))
+  })
+
+  it('if resetting the stillness timer in the firmware state machine is successful should print out the difference', async () => {
+    const sessionId = 'ca6e85b1-0a8c-4e1a-8d1e-7a35f838d7bc'
+    const newRespondedByPhoneNumber = '+18887774444'
+    const session = sessionFactory({ id: sessionId, respondedAt: null, respondedByPhoneNumber: null })
+    sandbox.stub(db, 'getSessionWithSessionId').returns(session)
+    const oldStillnessTimer = 5307
+    sandbox.stub(particleFunctions, 'resetStillnessTimer').returns(oldStillnessTimer)
+    sandbox.stub(helpers, 'log')
+
+    const braveAlerterConfigurator = new BraveAlerterConfigurator()
+    const braveAlerter = braveAlerterConfigurator.createBraveAlerter()
+    await braveAlerter.alertSessionChangedCallback(new AlertSession(sessionId, CHATBOT_STATE.WAITING_FOR_CATEGORY, newRespondedByPhoneNumber))
+
+    expect(helpers.log).to.be.calledWith(`Reset stillness timer for ${session.location.locationid} from ${oldStillnessTimer} to 0`)
+  })
+
+  it('if resetting the stillness timer in the firmware state machine is unsuccessful should out a message', async () => {
+    const sessionId = 'ca6e85b1-0a8c-4e1a-8d1e-7a35f838d7bc'
+    const newRespondedByPhoneNumber = '+18887774444'
+    const session = sessionFactory({ id: sessionId, respondedAt: null, respondedByPhoneNumber: null })
+    sandbox.stub(db, 'getSessionWithSessionId').returns(session)
+    sandbox.stub(particleFunctions, 'resetStillnessTimer').returns(-1)
+    sandbox.stub(helpers, 'log')
+
+    const braveAlerterConfigurator = new BraveAlerterConfigurator()
+    const braveAlerter = braveAlerterConfigurator.createBraveAlerter()
+    await braveAlerter.alertSessionChangedCallback(new AlertSession(sessionId, CHATBOT_STATE.WAITING_FOR_CATEGORY, newRespondedByPhoneNumber))
+
+    expect(helpers.log).to.be.calledWith(`Did not reset stillness timer for ${session.location.locationid}`)
   })
 
   it('if given alertState WAITING_FOR_CATEGORY and it has already been responded to should update alertState but not update respondedAt', async () => {

--- a/server/test/unit/BraveAlerterConfiguratorTest/alertSessionChangedCallbackTest.js
+++ b/server/test/unit/BraveAlerterConfiguratorTest/alertSessionChangedCallbackTest.js
@@ -64,14 +64,12 @@ describe('BraveAlerterConfigurator.js unit tests: alertSessionChangedCallback', 
     const braveAlerter = braveAlerterConfigurator.createBraveAlerter()
     await braveAlerter.alertSessionChangedCallback(new AlertSession(sessionId, CHATBOT_STATE.WAITING_FOR_CATEGORY, newRespondedByPhoneNumber))
 
-    const expectedSession = sessionFactory(
-      sessionFactory({
-        id: sessionId,
-        chatbotState: CHATBOT_STATE.WAITING_FOR_CATEGORY,
-        respondedAt: this.testCurrentTime,
-        respondedByPhoneNumber: newRespondedByPhoneNumber,
-      }),
-    )
+    const expectedSession = sessionFactory({
+      id: sessionId,
+      chatbotState: CHATBOT_STATE.WAITING_FOR_CATEGORY,
+      respondedAt: this.testCurrentTime,
+      respondedByPhoneNumber: newRespondedByPhoneNumber,
+    })
 
     expect(db.saveSession).to.be.calledWith(expectedSession, sandbox.any)
   })
@@ -88,14 +86,12 @@ describe('BraveAlerterConfigurator.js unit tests: alertSessionChangedCallback', 
     const braveAlerter = braveAlerterConfigurator.createBraveAlerter()
     await braveAlerter.alertSessionChangedCallback(new AlertSession(sessionId, CHATBOT_STATE.WAITING_FOR_CATEGORY, oldRespondedByPhoneNumber))
 
-    const expectedSession = sessionFactory(
-      sessionFactory({
-        id: sessionId,
-        chatbotState: CHATBOT_STATE.WAITING_FOR_CATEGORY,
-        respondedAt: testRespondedAtTime,
-        respondedByPhoneNumber: oldRespondedByPhoneNumber,
-      }),
-    )
+    const expectedSession = sessionFactory({
+      id: sessionId,
+      chatbotState: CHATBOT_STATE.WAITING_FOR_CATEGORY,
+      respondedAt: testRespondedAtTime,
+      respondedByPhoneNumber: oldRespondedByPhoneNumber,
+    })
 
     expect(db.saveSession).to.be.calledWith(expectedSession, sandbox.any)
   })
@@ -123,9 +119,13 @@ describe('BraveAlerterConfigurator.js unit tests: alertSessionChangedCallback', 
       client,
     })
     sandbox.stub(db, 'getLocationData').returns(location)
-    sandbox
-      .stub(db, 'getSessionWithSessionId')
-      .returns(sessionFactory({ id: sessionId, locationid: location.locationid, respondedByPhoneNumber: oldRespondedByPhoneNumber }))
+    sandbox.stub(db, 'getSessionWithSessionId').returns(
+      sessionFactory({
+        id: sessionId,
+        location,
+        respondedByPhoneNumber: oldRespondedByPhoneNumber,
+      }),
+    )
 
     const braveAlerterConfigurator = new BraveAlerterConfigurator()
     const braveAlerter = braveAlerterConfigurator.createBraveAlerter()
@@ -133,7 +133,7 @@ describe('BraveAlerterConfigurator.js unit tests: alertSessionChangedCallback', 
 
     const expectedSession = sessionFactory({
       id: sessionId,
-      locationid: location.locationid,
+      location,
       chatbotState: CHATBOT_STATE.COMPLETED,
       incidentCategory: 'No One Inside',
       respondedByPhoneNumber: oldRespondedByPhoneNumber,
@@ -152,7 +152,7 @@ describe('BraveAlerterConfigurator.js unit tests: alertSessionChangedCallback', 
     sandbox.stub(db, 'getLocationData').returns(location)
     sandbox
       .stub(db, 'getSessionWithSessionId')
-      .returns(sessionFactory({ id: sessionId, locationid: location.locationid, respondedByPhoneNumber: oldRespondedByPhoneNumber }))
+      .returns(sessionFactory({ id: sessionId, location, respondedByPhoneNumber: oldRespondedByPhoneNumber }))
 
     const braveAlerterConfigurator = new BraveAlerterConfigurator()
     const braveAlerter = braveAlerterConfigurator.createBraveAlerter()

--- a/server/test/unit/ParticleFunctionsTest/resetStillnessTimerTest.js
+++ b/server/test/unit/ParticleFunctionsTest/resetStillnessTimerTest.js
@@ -1,0 +1,164 @@
+// Third-party dependencies
+const { expect, use } = require('chai')
+const { afterEach, beforeEach, describe, it } = require('mocha')
+const sinon = require('sinon')
+const sinonChai = require('sinon-chai')
+const Particle = require('particle-api-js')
+const rewire = require('rewire')
+
+// In-house dependencies
+const { helpers } = require('brave-alert-lib')
+
+const particleFunctions = rewire('../../../particleFunctions')
+
+// Configure Chai
+use(sinonChai)
+
+const sandbox = sinon.createSandbox()
+
+describe('particleFunctions.js unit tests: resetStillnessTimer', () => {
+  /* eslint-disable no-underscore-dangle */
+  beforeEach(() => {
+    this.particle = new Particle()
+    particleFunctions.__set__('particle', this.particle)
+
+    sandbox.stub(helpers, 'log')
+  })
+
+  afterEach(() => {
+    sandbox.restore()
+  })
+
+  describe('given a Particle Device ID and Product ID', () => {
+    beforeEach(async () => {
+      this.deviceId = 'myDeviceId'
+      this.productId = 'myProductId'
+
+      sandbox.stub(this.particle, 'callFunction')
+
+      await particleFunctions.resetStillnessTimer(this.deviceId, this.productId)
+    })
+
+    it('should call the Particle API with the given Device ID and Product ID', () => {
+      expect(this.particle.callFunction).to.be.calledWithExactly({
+        deviceId: this.deviceId,
+        name: 'Reset_Stillness_Timer_For_Alerting_Session',
+        argument: '',
+        product: this.productId,
+        auth: helpers.getEnvVar('PARTICLE_ACCESS_TOKEN'),
+      })
+    })
+  })
+
+  describe('if the cloud function successfully reset the timer', () => {
+    beforeEach(async () => {
+      this.deviceId = 'myDeviceId'
+      this.productId = 'myProductId'
+      this.lengthOfOldStillnessTimer = 9823
+
+      sandbox.stub(this.particle, 'callFunction').returns({
+        body: {
+          connected: true,
+          id: this.deviceId,
+          return_value: this.lengthOfOldStillnessTimer,
+        },
+      })
+
+      this.response = await particleFunctions.resetStillnessTimer(this.deviceId, this.productId)
+    })
+
+    it('should return the old length of the stillness timer', () => {
+      expect(this.response).to.equal(this.lengthOfOldStillnessTimer)
+    })
+
+    it('should not log any errors', () => {
+      expect(helpers.log).not.to.be.called
+    })
+  })
+
+  describe('if a Sensor on Particle Console is offline', () => {
+    beforeEach(async () => {
+      this.deviceId = 'myDeviceId'
+      this.productId = 'myProductId'
+
+      sandbox.stub(this.particle, 'callFunction').throws({
+        statusCode: 400,
+        errorDescription:
+          'HTTP error 400 from https://api.particle.io/v1/products/12345/devices/e00fce680dcdd859b8089f31/Reset_Stillness_Timer_For_Alerting_Session',
+        error: {
+          ok: false,
+          error: 'timed out',
+          response: {
+            size: 0,
+            timeout: 0,
+            text: '{"ok":false,"error":"timed out"}',
+          },
+        },
+        body: {
+          ok: false,
+          error: 'timed out',
+          response: {
+            size: 0,
+            timeout: 0,
+            text: '{"ok":false,"error":"timed out"}',
+          },
+        },
+      })
+
+      this.response = await particleFunctions.resetStillnessTimer(this.deviceId, this.productId)
+    })
+
+    it('should return -1', () => {
+      expect(this.response).to.equal(-1)
+    })
+
+    it('should log the error', () => {
+      expect(helpers.log).to.be.calledWith(
+        `HTTP error 400 from https://api.particle.io/v1/products/12345/devices/e00fce680dcdd859b8089f31/Reset_Stillness_Timer_For_Alerting_Session : for device ${this.deviceId}`,
+      )
+    })
+  })
+
+  describe('if no such Sensor exists on Particle Console', () => {
+    beforeEach(async () => {
+      this.deviceId = 'myDeviceId'
+      this.productId = 'myProductId'
+
+      sandbox.stub(this.particle, 'callFunction').throws({
+        statusCode: 404,
+        errorDescription:
+          'HTTP error 404 from https://api.particle.io/v1/products/12345/devices/radar_coreID/Reset_Stillness_Timer_For_Alerting_Session',
+        error: {
+          ok: false,
+          error: 'Device not found.',
+          response: {
+            size: 0,
+            timeout: 0,
+            text: '{"ok":false,"error":"Device not found."}',
+          },
+        },
+        body: {
+          ok: false,
+          error: 'Device not found.',
+          response: {
+            size: 0,
+            timeout: 0,
+            text: '{"ok":false,"error":"Device not found."}',
+          },
+        },
+      })
+
+      this.response = await particleFunctions.resetStillnessTimer(this.deviceId, this.productId)
+    })
+
+    it('should return -1', () => {
+      expect(this.response).to.equal(-1)
+    })
+
+    it('should log the error', () => {
+      expect(helpers.log).to.be.calledWith(
+        `HTTP error 404 from https://api.particle.io/v1/products/12345/devices/radar_coreID/Reset_Stillness_Timer_For_Alerting_Session : for device ${this.deviceId}`,
+      )
+    })
+  })
+})

--- a/server/testingHelpers.js
+++ b/server/testingHelpers.js
@@ -94,7 +94,6 @@ function sessionFactory(overrides = {}) {
   // prettier-ignore
   return new Session(
     overrides.id !== undefined ? overrides.id : 'd91593b4-25ce-11ec-9621-0242ac130002',
-    overrides.locationid !== undefined ? overrides.locationid : 'myLocation',
     overrides.chatbotState !== undefined ? overrides.chatbotState : CHATBOT_STATE.COMPLETED,
     overrides.alertType !== undefined ? overrides.alertType : ALERT_TYPE.SENSOR_STILLNESS,
     overrides.createdAt !== undefined ? overrides.createdAt : new Date('2021-10-05T20:20:20.000Z'),
@@ -102,6 +101,7 @@ function sessionFactory(overrides = {}) {
     overrides.incidentCategory !== undefined ? overrides.incidentCategory : 'Overdose',
     overrides.respondedAt !== undefined ? overrides.respondedAt : new Date('2021-10-05T20:20:33.000Z'),
     overrides.respondedByPhoneNumber !== undefined ? overrides.respondedByPhoneNumber : '+17778886666',
+    overrides.location !== undefined ? overrides.location : locationFactory(),
   )
 }
 


### PR DESCRIPTION
- Create a new Particle cloud function that when called will reset the current Stillness Timer value, thus changing the state machine to wait at least another Stillness Threshold seconds before the next Stillness Alert
- Call this new cloud function whenever a Responder first responds to an alert

## Test plan
- [x] Deploy to Dev (use new AWS Dev environment)
- [x] Run smoketests
- [x] Hit the cloud function using Particle Console
   - [x] When in State 0 (idle)
      - [x] Nothing happens
      - [x] Returns -1 
   - [x] When in State 1 (initial)
      - [x] Nothing happens
      - [x] Returns -1
   - [x] When in State 2 (duration)
      - [x] Nothing happens
      - [x] Returns -1
   - [x] When in State 3 (stillness)
      - [x] When no alerts have happened yet
         - [x] Nothing happens
         - [x] Returns -1
      - [x] When a Stillness Alert has just occurred
         - [x] Can see the stillness timer value in the debug messages go to 0
         - [x] Returns the value of the stillness timer 
      - [x] When a Duration Alert has just occurred
         - [x] Can see the stillness timer value in the debug messages go to 0
         - [x] Returns the value of the stillness timer 
      - [x] When waiting for a Short Stillness Threshold
         - [x] Can see the stillness timer value in the debug messages go to 0
         - [x] Returns the value of the stillness timer 
      - [x] When waiting for the Long Stillness Threshold
- [x] Using my real device
   - [x] When in State 3 (stillness)
     - [x] Respond to a Duration Alert
        - [x] See the stillness timer value in the debug messages go to 0
        - [x] Stillness Alert occurs the right amount of time after that 
     - [x] Respond to a Short Stillness Alert 
        - [x] See the stillness timer value in the debug messages go to 0
        - [x] Stillness Alert occurs the right amount of time after that 
     - [x] Respond to a Long Stillness Alert
        - [x] See the stillness timer value in the debug messages go to 0
        - [x] Stillness Alert occurs the right amount of time after that 
  - [x] Logs the old and new stillness timer values
  - [x] Trigger a Stillness Alert, open door, second session is in state 3 (Stillness) but hasn't yet triggered a Stillness Alert, then Responder responds
     - [x] See that the stillness timer value in the debug message does NOT go to 0
  - [x] Trigger a Stillness Alert, open door, trigger a Stillness Alert in second session, be in state 3 (Stillness), then Responder responds
      - [x] See the stillness timer value in the debug messages go to 0
  - [x] Trigger a Duration Alert, open door, trigger a Stillness Alert in second session, be in state 3 (Stillness), then Responder responds
      - [x] See the stillness timer value in the debug messages go to 0
   - [x] What happens if the firmware is an older version when the Responder responds? - It logs `HTTP error 404 from https://api.particle.io/v1/products/<productId>/devices/e00fce680dcdd859b8089f31/Reset_Stillness_Timer_For_Alerting_Session : for device <deviceId>`
   - [x] Does not send more than one Duration Alert per session
- [x] When a Device that is registered on Particle Console is disconnected/offline
   - [x] Should log the error
- [x] When a device doesn't isn't registered on Particle Console (i.e. when running the smoketests)
   - [x] Should log the error