### PR TITLE
Timeout "Window" in state 0 for allowable entrance into state 1 (CU-8678t4ztg)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ the code was deployed.
 ### Added
 
 - CORS configuration to Express Proxy Middleware.
+- Added a window of time after the door closes where the sensor is allowed to detect for occupation
+- Added console function for the window aswell as timer status and window size in Debug Publishes
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,14 @@ the code was deployed.
 ### Added
 
 - CORS configuration to Express Proxy Middleware.
-- Added a window of time after the door closes where the sensor is allowed to detect for occupation (CU-8678t4ztg)
-- Added console function for the window aswell as timer status and window size in Debug Publishes (CU-8678t4ztg)
-- "doorMissedFrequently" field to JSON data submitted by brave sensors that is sent to /api/heartbeat (CU-860rk8v2a)
-- Sentry log in the case that doorMissedFrequently is true in posted data from brave sensor (CU-860rk8v2a)
+- Added a timer in state0 that is reset when the door closes where the sensor is allowed to detect for occupation (CU-8678t4ztg).
+- Added console function for the occupation detection timer as well as the timer count and timeout value in Debug Publishes (CU-8678t4ztg).
+- "doorMissedFrequently" field to JSON data submitted by brave sensors that is sent to /api/heartbeat (CU-860rk8v2a).
+- Sentry log in the case that doorMissedFrequently is true in posted data from brave sensor (CU-860rk8v2a).
+
+### Fixed
+
+- Wording in consoleFunctionTests.cpp when functions are called with 'e'.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ the code was deployed.
 ### Added
 
 - CORS configuration to Express Proxy Middleware.
-- Added a timer in state0 that is reset when the door closes where the sensor is allowed to detect for occupation (CU-8678t4ztg).
+- Added a timer in state0 that is reset when the door closes during which the sensor is allowed to detect for occupation (CU-8678t4ztg).
 - Added console function for the occupation detection timer as well as the timer count and timeout value in Debug Publishes (CU-8678t4ztg).
 - "doorMissedFrequently" field to JSON data submitted by brave sensors that is sent to /api/heartbeat (CU-860rk8v2a).
 - Sentry log in the case that doorMissedFrequently is true in posted data from brave sensor (CU-860rk8v2a).

--- a/firmware/README.md
+++ b/firmware/README.md
@@ -12,7 +12,7 @@
      - [DEBUG_LEVEL](#debug_level)
      - [BRAVE_PRODUCT_ID for state machine](#brave_product_id-for-state-machine)
      - [INS_THRESHOLD](#ins_threshold)
-     - [STATE0_WINDOW_TIME](#state0_window_time)
+     - [STATE0_OCCUPANT_DETECTION_TIMER](#state0_occupant_detection_timer)
      - [STATE1_MAX_TIME](#state1_max_time)
      - [STATE2_MAX_DURATION](#state2_max_duration)
      - [STATE3_MAX_STILLNESS_TIME](#state3_max_stillness_time)
@@ -181,11 +181,11 @@ It is compared to the filtered inPhase values detected by the INS radar. Anythin
 
 The default level is set to 60. This is based on the radar testing documented [here](https://docs.google.com/document/d/12TLw6XE9CSaNpguytS2NCSCP0aZWUs-OncmaDdoTKfo/edit?usp=sharing).
 
-### STATE0_WINDOW_TIME
+### STATE0_OCCUPANT_DETECTION_TIMER
 
 This is defined via a macro in the stateMachine.h header file
 
-It is the length of time (or window) after the door_status changes from an open to a closed state where entrance to state1 is allowed. After the state 0 timer has surpassed this window, the state machine with still in state 0 until this timer reset (door open and close) 
+It is the length of time after the door_status changes from an open to a closed state where entrance to state1 is allowed. After the state 0 timer has surpassed this value, the state machine will stay in state 0 until this timer resets (door open and close) 
 
 The length of time is default to 1 hour defined as 3600000 milliseconds
 
@@ -332,21 +332,21 @@ Stillness timer is the length of time the Sensor sees stillness before publishin
 - The integer number of seconds of the current timer value, when e for echo is entered
 - -1: when bad data is entered
 
-### **window_size_set(String)**
+### **occupant_detection_timer_set(String)**
 
 **Description:**
 
-Window is the allowed time after the paired door sensor closes in which state 0 can transition to state 1. The default value is 60 minutes. Use this console function to set the window size (time) 
+This sets the allowed time after the paired door sensor closes in which state 0 can transition to state 1. The default value is 60 minutes.
 
 **Argument(s):**
 
-1. The integer number of seconds of the new window timeout.
-2. e - this is short for echo, and will echo the current window timeout
+1. The integer number of seconds of the new occupation detection timer.
+2. e - this is short for echo, and will echo the current occupation detection timer
 
 **Return(s):**
 
-- The integer number of seconds of the timeout value, when a new timeout value is entered
-- The integer number of seconds of the current timeout value, when e for echo is entered
+- The integer number of seconds of the timer value, when a new timer value is entered
+- The integer number of seconds of the current timer value, when e for echo is entered
 - -1: when bad data is entered
 
 ### **initial_timer_set(String)**

--- a/firmware/README.md
+++ b/firmware/README.md
@@ -12,6 +12,7 @@
      - [DEBUG_LEVEL](#debug_level)
      - [BRAVE_PRODUCT_ID for state machine](#brave_product_id-for-state-machine)
      - [INS_THRESHOLD](#ins_threshold)
+     - [STATE0_WINDOW_TIME](#state0_window_time)
      - [STATE1_MAX_TIME](#state1_max_time)
      - [STATE2_MAX_DURATION](#state2_max_duration)
      - [STATE3_MAX_STILLNESS_TIME](#state3_max_stillness_time)
@@ -179,6 +180,14 @@ This is defined via a macro in the stateMachine.h header file.
 It is compared to the filtered inPhase values detected by the INS radar. Anything above the threshold is considered movement, and anything below the threshold is considered stillness or an empty room.
 
 The default level is set to 60. This is based on the radar testing documented [here](https://docs.google.com/document/d/12TLw6XE9CSaNpguytS2NCSCP0aZWUs-OncmaDdoTKfo/edit?usp=sharing).
+
+### STATE0_WINDOW_TIME
+
+This is defined via a macro in the stateMachine.h header file
+
+It is the length of time (or window) after the door_status changes from an open to a closed state where entrance to state1 is allowed. After the state 0 timer has surpassed this window, the state machine with still in state 0 until this timer reset (door open and close) 
+
+The length of time is default to 1 hour defined as 3600000 milliseconds
 
 ### STATE1_MAX_TIME
 

--- a/firmware/README.md
+++ b/firmware/README.md
@@ -556,7 +556,7 @@ Debug Message
 1. INS_val: the current filtered inPhase value from the INS radar
 1. INS_threshold: the current threshold that we compare the INS_val against
 1. timer_status: if the current state uses a timer, this contains the time in milliseconds that the timer has counted up to thus far. If the current state does not contain a timer, this is set to 0.
-1. window_size: the window timeout value that that the idle state timer compares against
+1. occupation_detection_timer: the occupation detection timer value that that the idle state compares against
 1. initial_timer: the initial timer value that the initial state compares against
 1. duration_timer: the duration timer value that the duration and stillness states compare against
 1. stillness_timer: the stillness timer value that the stillness state compares against

--- a/firmware/boron-ins-fsm/src/BraveSensorProductionFirmware.ino
+++ b/firmware/boron-ins-fsm/src/BraveSensorProductionFirmware.ino
@@ -11,7 +11,7 @@
 #include "tpl5010watchdog.h"
 
 #define DEBUG_LEVEL            LOG_LEVEL_INFO
-#define BRAVE_FIRMWARE_VERSION 9060   // see versioning notes in the readme
+#define BRAVE_FIRMWARE_VERSION 3898   // see versioning notes in the readme
 #define BRAVE_PRODUCT_ID       14807  // 14807 = beta units, 15479 = production units
 
 PRODUCT_ID(BRAVE_PRODUCT_ID);             // you get this number off the particle console, see readme for instructions

--- a/firmware/boron-ins-fsm/src/consoleFunctions.cpp
+++ b/firmware/boron-ins-fsm/src/consoleFunctions.cpp
@@ -23,6 +23,7 @@ void setupConsoleFunctions() {
     // particle console function declarations, belongs in setup() as per docs
     Particle.function("Force_Reset", force_reset);
     Particle.function("Turn_Debugging_Publishes_On_Off", toggle_debugging_publishes);
+    Particle.function("Change_Occupant_Detection_Window", window_size_set);
     Particle.function("Change_Initial_Timer", initial_timer_set);
     Particle.function("Change_Duration_Timer", duration_timer_set);
     Particle.function("Change_Stillness_Timer", stillness_timer_set);
@@ -78,6 +79,40 @@ int toggle_debugging_publishes(String command) {
         returnFlag = -1;
     }
 
+    return returnFlag;
+}
+
+// returns initial timer length if valid input is given, otherwise returns -1
+int window_size_set(String input) {
+    int returnFlag = -1;
+
+    const char* holder = input.c_str();
+
+    // if e, echo the current threshold
+    if (*holder == 'e') {
+        EEPROM.get(ADDR_STATE0_WINDOW_TIME, state0_window_time);
+        returnFlag = state0_window_time / 1000;
+    }
+    // else parse new threshold
+    else {
+        int timeout = input.toInt();
+        // increase timeout value to from seconds to ms
+        timeout = timeout * 1000;
+
+        if (timeout == 0) {
+            // string.toInt() returns 0 if input not an int
+            // and a threshold value of 0 makes no sense, so return -1
+            returnFlag = -1;
+        }
+        else if (timeout < 0) {
+            returnFlag = -1;
+        }
+        else {
+            EEPROM.put(ADDR_STATE0_WINDOW_TIME, timeout);
+            state0_window_time = timeout;
+            returnFlag = state0_window_time / 1000;
+        }
+    }
     return returnFlag;
 }
 

--- a/firmware/boron-ins-fsm/src/consoleFunctions.cpp
+++ b/firmware/boron-ins-fsm/src/consoleFunctions.cpp
@@ -23,7 +23,7 @@ void setupConsoleFunctions() {
     // particle console function declarations, belongs in setup() as per docs
     Particle.function("Force_Reset", force_reset);
     Particle.function("Turn_Debugging_Publishes_On_Off", toggle_debugging_publishes);
-    Particle.function("Change_Occupant_Detection_Window", window_size_set);
+    Particle.function("Change_Occupant_Detection_Timer", occupant_detection_timer_set);
     Particle.function("Change_Initial_Timer", initial_timer_set);
     Particle.function("Change_Duration_Timer", duration_timer_set);
     Particle.function("Change_Stillness_Timer", stillness_timer_set);
@@ -82,16 +82,16 @@ int toggle_debugging_publishes(String command) {
     return returnFlag;
 }
 
-// returns initial timer length if valid input is given, otherwise returns -1
-int window_size_set(String input) {
+// returns occupant detection timer if valid input is given, otherwise returns -1
+int occupant_detection_timer_set(String input) {
     int returnFlag = -1;
 
     const char* holder = input.c_str();
 
     // if e, echo the current threshold
     if (*holder == 'e') {
-        EEPROM.get(ADDR_STATE0_WINDOW_TIME, state0_window_time);
-        returnFlag = state0_window_time / 1000;
+        EEPROM.get(ADDR_STATE0_OCCUPANT_DETECTION_TIMER, state0_occupant_detection_timer);
+        returnFlag = state0_occupant_detection_timer / 1000;
     }
     // else parse new threshold
     else {
@@ -108,9 +108,9 @@ int window_size_set(String input) {
             returnFlag = -1;
         }
         else {
-            EEPROM.put(ADDR_STATE0_WINDOW_TIME, timeout);
-            state0_window_time = timeout;
-            returnFlag = state0_window_time / 1000;
+            EEPROM.put(ADDR_STATE0_OCCUPANT_DETECTION_TIMER, timeout);
+            state0_occupant_detection_timer = timeout;
+            returnFlag = state0_occupant_detection_timer / 1000;
         }
     }
     return returnFlag;

--- a/firmware/boron-ins-fsm/src/consoleFunctions.h
+++ b/firmware/boron-ins-fsm/src/consoleFunctions.h
@@ -18,7 +18,7 @@ void setupConsoleFunctions();
 // console functions
 int stillness_timer_set(String);
 int long_stillness_timer_set(String);
-int window_size_set(String);
+int occupant_detection_timer_set(String);
 int initial_timer_set(String);
 int duration_timer_set(String);
 int ins_threshold_set(String);

--- a/firmware/boron-ins-fsm/src/consoleFunctions.h
+++ b/firmware/boron-ins-fsm/src/consoleFunctions.h
@@ -18,6 +18,7 @@ void setupConsoleFunctions();
 // console functions
 int stillness_timer_set(String);
 int long_stillness_timer_set(String);
+int window_size_set(String);
 int initial_timer_set(String);
 int duration_timer_set(String);
 int ins_threshold_set(String);

--- a/firmware/boron-ins-fsm/src/flashAddresses.h
+++ b/firmware/boron-ins-fsm/src/flashAddresses.h
@@ -34,6 +34,10 @@
 #define ADDR_STATE3_MAX_LONG_STILLNESS_TIME                 23  // uint32_t = 4 bytes
 #define ADDR_INITIALIZE_STATE3_MAX_LONG_STILLNESS_TIME_FLAG 27  // uint16_2 = 2 bytes
 
-// next available address is 27 + 2 = 29
+// new state machine constant for state0 window
+#define ADDR_INITIALIZE_STATE0_WINDOW_FLAG                  29  // uint16_2 = 2 bytes
+#define ADDR_STATE0_WINDOW_TIME                             31  // uint32_t = 4 bytes
+
+// next available address is 31 + 4 = 35
 
 #endif

--- a/firmware/boron-ins-fsm/src/flashAddresses.h
+++ b/firmware/boron-ins-fsm/src/flashAddresses.h
@@ -35,8 +35,8 @@
 #define ADDR_INITIALIZE_STATE3_MAX_LONG_STILLNESS_TIME_FLAG 27  // uint16_2 = 2 bytes
 
 // new state machine constant for state0 window
-#define ADDR_INITIALIZE_STATE0_WINDOW_FLAG                  29  // uint16_2 = 2 bytes
-#define ADDR_STATE0_WINDOW_TIME                             31  // uint32_t = 4 bytes
+#define ADDR_INITIALIZE_STATE0_OCCUPANT_DETECTION_TIMER_FLAG 29  // uint16_2 = 2 bytes
+#define ADDR_STATE0_OCCUPANT_DETECTION_TIMER                 31  // uint32_t = 4 bytes
 
 // next available address is 31 + 4 = 35
 

--- a/firmware/boron-ins-fsm/src/imDoorSensor.cpp
+++ b/firmware/boron-ins-fsm/src/imDoorSensor.cpp
@@ -18,7 +18,7 @@ bool doorTamperedFlag = false;
 bool doorMessageReceivedFlag = false;
 unsigned long doorHeartbeatReceived = 0;
 unsigned long doorLastMessage = 0;
-unsigned long timeSinceDoorClosed = 0;
+unsigned long timeWhenDoorClosed = 0;
 
 //**********setup()******************
 
@@ -72,7 +72,7 @@ doorData checkIM() {
 
         // Set timer starting when door closes
         if ((previousDoorData.doorStatus & 0b0010) != 0 && (currentDoorData.doorStatus & 0b0010) == 0) {
-            timeSinceDoorClosed = millis();
+            timeWhenDoorClosed = millis();
         }
 
         // After a certain thereshold, the next door message received will trigger a boron heartbeat

--- a/firmware/boron-ins-fsm/src/imDoorSensor.cpp
+++ b/firmware/boron-ins-fsm/src/imDoorSensor.cpp
@@ -18,6 +18,7 @@ bool doorTamperedFlag = false;
 bool doorMessageReceivedFlag = false;
 unsigned long doorHeartbeatReceived = 0;
 unsigned long doorLastMessage = 0;
+unsigned long timeSinceDoorClosed = 0;
 
 //**********setup()******************
 
@@ -68,6 +69,11 @@ doorData checkIM() {
 
         // Checks if the 0th bit (counting from 0) of doorStatus is 1
         doorTamperedFlag = (currentDoorData.doorStatus & 0b0001) != 0;
+
+        // Set timer starting when door closes
+        if ((previousDoorData.doorStatus & 0b0010) != 0 && (currentDoorData.doorStatus & 0b0010) == 0) {
+            timeSinceDoorClosed = millis();
+        }
 
         // After a certain thereshold, the next door message received will trigger a boron heartbeat
         if (millis() - doorLastMessage >= MSG_TRIGGER_SM_HEARTBEAT_THRESHOLD) {

--- a/firmware/boron-ins-fsm/src/imDoorSensor.cpp
+++ b/firmware/boron-ins-fsm/src/imDoorSensor.cpp
@@ -70,9 +70,11 @@ doorData checkIM() {
         // Checks if the 0th bit (counting from 0) of doorStatus is 1
         doorTamperedFlag = (currentDoorData.doorStatus & 0b0001) != 0;
 
-        // Set timer starting when door closes
-        if ((previousDoorData.doorStatus & 0b0010) != 0 && (currentDoorData.doorStatus & 0b0010) == 0) {
-            timeWhenDoorClosed = millis();
+        // Reset timer on receiving a door close message or transition from open to closed + heartbeat
+        if ((currentDoorData.doorStatus & 0b0010) == 0) {
+            if ((currentDoorData.doorStatus & 0b1000) == 0 || (previousDoorData.doorStatus & 0b0010) != 0) {
+                timeWhenDoorClosed = millis();
+            }
         }
 
         // After a certain thereshold, the next door message received will trigger a boron heartbeat

--- a/firmware/boron-ins-fsm/src/imDoorSensor.h
+++ b/firmware/boron-ins-fsm/src/imDoorSensor.h
@@ -53,7 +53,7 @@ extern bool doorTamperedFlag;
 extern bool doorMessageReceivedFlag;
 extern unsigned long doorHeartbeatReceived;
 extern unsigned long doorLastMessage;
-extern unsigned long timeSinceDoorClosed;
+extern unsigned long timeWhenDoorClosed;
 
 // setup() functions
 void setupIM(void);

--- a/firmware/boron-ins-fsm/src/imDoorSensor.h
+++ b/firmware/boron-ins-fsm/src/imDoorSensor.h
@@ -53,6 +53,7 @@ extern bool doorTamperedFlag;
 extern bool doorMessageReceivedFlag;
 extern unsigned long doorHeartbeatReceived;
 extern unsigned long doorLastMessage;
+extern unsigned long timeSinceDoorClosed;
 
 // setup() functions
 void setupIM(void);

--- a/firmware/boron-ins-fsm/src/stateMachine.cpp
+++ b/firmware/boron-ins-fsm/src/stateMachine.cpp
@@ -15,13 +15,12 @@
 StateHandler stateHandler = state0_idle;
 
 // define global variables so they are allocated in memory
-unsigned long state0_time_when_door_closed;
 unsigned long state1_timer;
 unsigned long state2_duration_timer;
 unsigned long state3_stillness_timer;
 // initialize constants to sensible default values
 unsigned long ins_threshold = INS_THRESHOLD;
-unsigned long state0_window_time = STATE0_WINDOW_TIME;
+unsigned long state0_occupant_detection_timer = STATE0_OCCUPANT_DETECTION_TIMER;
 unsigned long state1_max_time = STATE1_MAX_TIME;
 unsigned long state2_max_duration = STATE2_MAX_DURATION;
 unsigned long state3_max_stillness_time = STATE3_MAX_STILLNESS_TIME;
@@ -57,7 +56,7 @@ void setupStateMachine() {
 void initializeStateMachineConsts() {
     uint16_t initializeConstsFlag;
     uint16_t initializeState3MaxLongStillenssTimeFlag;
-    uint16_t initializeState0WindowFlag;
+    uint16_t initializeState0OccupationDetectionFlag;
 
     // Boron flash memory is initialized to all F's (1's)
     EEPROM.get(ADDR_INITIALIZE_SM_CONSTS_FLAG, initializeConstsFlag);
@@ -100,17 +99,17 @@ void initializeStateMachineConsts() {
     }
 
     // Seperate initialization for State 0 Window
-    EEPROM.get(ADDR_INITIALIZE_STATE0_WINDOW_FLAG, initializeState0WindowFlag);
-    Log.info("state machine constant State3MaxLongStillnessTime flag is 0x%04X", initializeState0WindowFlag);
+    EEPROM.get(ADDR_INITIALIZE_STATE0_OCCUPANT_DETECTION_TIMER_FLAG, initializeState0OccupationDetectionFlag);
+    Log.info("state machine constant State3MaxLongStillnessTime flag is 0x%04X", initializeState0OccupationDetectionFlag);
 
-    if (initializeState0WindowFlag != INITIALIZE_STATE0_WINDOW_FLAG) {
-        EEPROM.put(ADDR_STATE0_WINDOW_TIME, state0_window_time);
-        initializeState0WindowFlag = INITIALIZE_STATE0_WINDOW_FLAG;
-        EEPROM.put(ADDR_INITIALIZE_STATE0_WINDOW_FLAG, initializeState0WindowFlag);
+    if (initializeState0OccupationDetectionFlag != INITIALIZE_STATE0_OCCUPANT_DETECTION_FLAG) {
+        EEPROM.put(ADDR_STATE0_OCCUPANT_DETECTION_TIMER, state0_occupant_detection_timer);
+        initializeState0OccupationDetectionFlag = INITIALIZE_STATE0_OCCUPANT_DETECTION_FLAG;
+        EEPROM.put(ADDR_INITIALIZE_STATE0_OCCUPANT_DETECTION_TIMER_FLAG, initializeState0OccupationDetectionFlag);
         Log.info("State machine constant State3MaxLongStillnessTime was written to flash on bootup.");
     }
     else {
-        EEPROM.get(ADDR_STATE0_WINDOW_TIME, state0_window_time);
+        EEPROM.get(ADDR_STATE0_OCCUPANT_DETECTION_TIMER, state0_occupant_detection_timer);
         Log.info("State machine constant State3MaxLongStillnessTime was read from flash on bootup.");
     }
 }
@@ -144,10 +143,11 @@ void state0_idle() {
 
     Log.info("You are in state 0, idle: Door status, iAverage = 0x%02X, %f", checkDoor.doorStatus, checkINS.iAverage);
     // default timer to 0 when state doesn't have a timer
-    publishDebugMessage(0, checkDoor.doorStatus, checkINS.iAverage, (millis() - timeSinceDoorClosed));
+    publishDebugMessage(0, checkDoor.doorStatus, checkINS.iAverage, (millis() - timeWhenDoorClosed));
 
     // fix outputs and state exit conditions accordingly
-    if (((unsigned long)checkINS.iAverage > ins_threshold) && !isDoorOpen(checkDoor.doorStatus) && !isDoorStatusUnknown(checkDoor.doorStatus) && millis() - timeSinceDoorClosed < state0_window_time) {
+    if (millis() - timeWhenDoorClosed < state0_occupant_detection_timer && ((unsigned long)checkINS.iAverage > ins_threshold) &&
+        !isDoorOpen(checkDoor.doorStatus) && !isDoorStatusUnknown(checkDoor.doorStatus)) {
         Log.warn("In state 0, door closed and seeing movement, heading to state 1");
         publishStateTransition(0, 1, checkDoor.doorStatus, checkINS.iAverage);
         saveStateChangeOrAlert(0, 0);
@@ -331,8 +331,9 @@ void publishDebugMessage(int state, unsigned char doorStatus, float INSValue, un
             char debugMessage[622];
             snprintf(debugMessage, sizeof(debugMessage),
                      "{\"state\":\"%d\", \"door_status\":\"0x%02X\", \"INS_val\":\"%f\", \"INS_threshold\":\"%lu\", \"timer_status\":\"%lu\", "
-                     "\"window_size\":\"%lu\", \"initial_timer\":\"%lu\", \"duration_timer\":\"%lu\", \"stillness_timer\":\"%lu\"}",
-                     state, doorStatus, INSValue, ins_threshold, timer, state0_window_time, state1_max_time, state2_max_duration, *max_stillness_time);
+                     "\"occupation_detection_timer\":\"%lu\", \"initial_timer\":\"%lu\", \"duration_timer\":\"%lu\", \"stillness_timer\":\"%lu\"}",
+                     state, doorStatus, INSValue, ins_threshold, timer, state0_occupant_detection_timer, state1_max_time, state2_max_duration,
+                     *max_stillness_time);
             Particle.publish("Debug Message", debugMessage, PRIVATE);
             lastDebugPublish = millis();
         }

--- a/firmware/boron-ins-fsm/src/stateMachine.cpp
+++ b/firmware/boron-ins-fsm/src/stateMachine.cpp
@@ -106,11 +106,11 @@ void initializeStateMachineConsts() {
         EEPROM.put(ADDR_STATE0_OCCUPANT_DETECTION_TIMER, state0_occupant_detection_timer);
         initializeState0OccupationDetectionFlag = INITIALIZE_STATE0_OCCUPANT_DETECTION_FLAG;
         EEPROM.put(ADDR_INITIALIZE_STATE0_OCCUPANT_DETECTION_TIMER_FLAG, initializeState0OccupationDetectionFlag);
-        Log.info("State machine constant State3MaxLongStillnessTime was written to flash on bootup.");
+        Log.info("State machine constant State0OccupationDetectionTimer was written to flash on bootup.");
     }
     else {
         EEPROM.get(ADDR_STATE0_OCCUPANT_DETECTION_TIMER, state0_occupant_detection_timer);
-        Log.info("State machine constant State3MaxLongStillnessTime was read from flash on bootup.");
+        Log.info("State machine constant State0OccupationDetectionTimer was read from flash on bootup.");
     }
 }
 

--- a/firmware/boron-ins-fsm/src/stateMachine.h
+++ b/firmware/boron-ins-fsm/src/stateMachine.h
@@ -12,12 +12,12 @@
 // which is also unlikely to be part of a door ID or a threshold/timer const
 #define INITIALIZE_STATE_MACHINE_CONSTS_FLAG           0x8888
 #define INITIALIZE_STATE3_MAX_LONG_STILLNESS_TIME_FLAG 0x8888
-#define INITIALIZE_STATE0_WINDOW_FLAG                  0x8888
+#define INITIALIZE_STATE0_OCCUPANT_DETECTION_FLAG      0x8888
 
 // initial (default) values for state machine, can be changed via console function
 // or by writing something other than 0x8888 to the above flag in flash
 #define INS_THRESHOLD                   60
-#define STATE0_WINDOW_TIME              3600000  // ms = 60 min
+#define STATE0_OCCUPANT_DETECTION_TIMER 3600000  // ms = 60 min
 #define STATE1_MAX_TIME                 15000    // ms = 15s
 #define STATE2_MAX_DURATION             1200000  // ms = 20 min
 #define STATE3_MAX_STILLNESS_TIME       120000   // ms = 2 minutes
@@ -72,7 +72,7 @@ extern unsigned long state3_stillness_timer;
 
 // state machine constants stored in flash
 extern unsigned long ins_threshold;
-extern unsigned long state0_window_time;
+extern unsigned long state0_occupant_detection_timer;
 extern unsigned long state1_max_time;
 extern unsigned long state2_max_duration;
 extern unsigned long state3_max_stillness_time;

--- a/firmware/boron-ins-fsm/src/stateMachine.h
+++ b/firmware/boron-ins-fsm/src/stateMachine.h
@@ -12,13 +12,15 @@
 // which is also unlikely to be part of a door ID or a threshold/timer const
 #define INITIALIZE_STATE_MACHINE_CONSTS_FLAG           0x8888
 #define INITIALIZE_STATE3_MAX_LONG_STILLNESS_TIME_FLAG 0x8888
+#define INITIALIZE_STATE0_WINDOW_FLAG                  0x8888
 
 // initial (default) values for state machine, can be changed via console function
 // or by writing something other than 0x8888 to the above flag in flash
-#define INS_THRESHOLD             60
-#define STATE1_MAX_TIME           15000    // ms = 15s
-#define STATE2_MAX_DURATION       1200000  // ms = 20 min
-#define STATE3_MAX_STILLNESS_TIME 120000   // ms = 2 minutes
+#define INS_THRESHOLD                   60
+#define STATE0_WINDOW_TIME              3600000  // ms = 60 min
+#define STATE1_MAX_TIME                 15000    // ms = 15s
+#define STATE2_MAX_DURATION             1200000  // ms = 20 min
+#define STATE3_MAX_STILLNESS_TIME       120000   // ms = 2 minutes
 
 // How often to publish Heartbeat messages
 #define SM_HEARTBEAT_INTERVAL 660000  // ms = 11 min
@@ -67,6 +69,7 @@ extern unsigned long state3_stillness_timer;
 
 // state machine constants stored in flash
 extern unsigned long ins_threshold;
+extern unsigned long state0_window_time;
 extern unsigned long state1_max_time;
 extern unsigned long state2_max_duration;
 extern unsigned long state3_max_stillness_time;

--- a/firmware/boron-ins-fsm/src/stateMachine.h
+++ b/firmware/boron-ins-fsm/src/stateMachine.h
@@ -17,10 +17,10 @@
 // initial (default) values for state machine, can be changed via console function
 // or by writing something other than 0x8888 to the above flag in flash
 #define INS_THRESHOLD                   60
-#define STATE0_OCCUPANT_DETECTION_TIMER 3600000  // ms = 60 min
-#define STATE1_MAX_TIME                 15000    // ms = 15s
-#define STATE2_MAX_DURATION             1200000  // ms = 20 min
-#define STATE3_MAX_STILLNESS_TIME       120000   // ms = 2 minutes
+#define STATE0_OCCUPANT_DETECTION_TIMER 172800000  // 2 days
+#define STATE1_MAX_TIME                 15000      // ms = 15s
+#define STATE2_MAX_DURATION             1200000    // ms = 20 min
+#define STATE3_MAX_STILLNESS_TIME       120000     // ms = 2 minutes
 
 // How often to publish Heartbeat messages
 #define SM_HEARTBEAT_INTERVAL 660000  // ms = 11 min

--- a/firmware/boron-ins-fsm/test/base.h
+++ b/firmware/boron-ins-fsm/test/base.h
@@ -30,6 +30,7 @@ MockBLE BLE;
 
 bool stateMachineDebugFlag;
 unsigned long debugFlagTurnedOnAt;
+long unsigned state0_occupant_detection_timer;
 long unsigned state1_max_time;
 long unsigned state2_max_duration;
 long unsigned state3_max_stillness_time;

--- a/firmware/boron-ins-fsm/test/consoleFunctionTests.cpp
+++ b/firmware/boron-ins-fsm/test/consoleFunctionTests.cpp
@@ -143,6 +143,60 @@ SCENARIO("Change_IM21_Door_ID", "[change door id]") {
     }
 }
 
+SCENARIO("Set Window Time", "[window time]") {
+    GIVEN("A starting window time of 1 minute") {
+        state0_window_time = 60000;
+
+        WHEN("the function is called with 'e'") {
+            int returnFlag = window_size_set("e");
+
+            THEN("the initial timer value should remain the same") {
+                REQUIRE(state0_window_time == 60000);
+            }
+
+            THEN("the function should return the input") {
+                REQUIRE(returnFlag == 60);
+            }
+        }
+
+        WHEN("the function is called with a positive integer") {
+            int returnFlag = window_size_set("30");
+
+            THEN("the initial timer value should be updated to the input * 1000") {
+                REQUIRE(state0_window_time == 30000);
+            }
+
+            THEN("the function should return the input") {
+                REQUIRE(returnFlag == 30);
+            }
+        }
+
+        WHEN("the function is called with a negative integer") {
+            int returnFlag = window_size_set("-30");
+
+            THEN("the initial timer value should not be updated") {
+                REQUIRE(state0_window_time == 60000);
+            }
+
+            THEN("the function should return -1 to indicate an error") {
+                REQUIRE(returnFlag == -1);
+            }
+        }
+
+        WHEN("the function is called with something other than 'e' or a positive integer") {
+            int returnFlag = window_size_set("nonInt");
+
+            THEN("the initial timer value should not be updated") {
+                REQUIRE(state0_window_time == 60000);
+            }
+
+            THEN("the function should return -1 to indicate an error") {
+                REQUIRE(returnFlag == -1);
+            }
+        }
+    }
+}
+
 SCENARIO("Set Initial Timer", "[initial timer]") {
     GIVEN("A starting initial timer of 10 milliseconds") {
         state1_max_time = 10000;

--- a/firmware/boron-ins-fsm/test/consoleFunctionTests.cpp
+++ b/firmware/boron-ins-fsm/test/consoleFunctionTests.cpp
@@ -143,27 +143,27 @@ SCENARIO("Change_IM21_Door_ID", "[change door id]") {
     }
 }
 
-SCENARIO("Set Window Time", "[window time]") {
-    GIVEN("A starting window time of 1 minute") {
-        state0_window_time = 60000;
+SCENARIO("Set Occupation Detection Timer", "[occupation detection timer]") {
+    GIVEN("A starting occupation detection timer of 1 minute") {
+        state0_occupant_detection_timer = 60000;
 
         WHEN("the function is called with 'e'") {
-            int returnFlag = window_size_set("e");
+            int returnFlag = occupant_detection_timer_set("e");
 
             THEN("the initial timer value should remain the same") {
-                REQUIRE(state0_window_time == 60000);
+                REQUIRE(state0_occupant_detection_timer == 60000);
             }
 
-            THEN("the function should return the input") {
+            THEN("the function should return the stored value") {
                 REQUIRE(returnFlag == 60);
             }
         }
 
         WHEN("the function is called with a positive integer") {
-            int returnFlag = window_size_set("30");
+            int returnFlag = occupant_detection_timer_set("30");
 
             THEN("the initial timer value should be updated to the input * 1000") {
-                REQUIRE(state0_window_time == 30000);
+                REQUIRE(state0_occupant_detection_timer == 30000);
             }
 
             THEN("the function should return the input") {
@@ -172,10 +172,10 @@ SCENARIO("Set Window Time", "[window time]") {
         }
 
         WHEN("the function is called with a negative integer") {
-            int returnFlag = window_size_set("-30");
+            int returnFlag = occupant_detection_timer_set("-30");
 
             THEN("the initial timer value should not be updated") {
-                REQUIRE(state0_window_time == 60000);
+                REQUIRE(state0_occupant_detection_timer == 60000);
             }
 
             THEN("the function should return -1 to indicate an error") {
@@ -184,10 +184,10 @@ SCENARIO("Set Window Time", "[window time]") {
         }
 
         WHEN("the function is called with something other than 'e' or a positive integer") {
-            int returnFlag = window_size_set("nonInt");
+            int returnFlag = occupant_detection_timer_set("nonInt");
 
             THEN("the initial timer value should not be updated") {
-                REQUIRE(state0_window_time == 60000);
+                REQUIRE(state0_occupant_detection_timer == 60000);
             }
 
             THEN("the function should return -1 to indicate an error") {
@@ -208,7 +208,7 @@ SCENARIO("Set Initial Timer", "[initial timer]") {
                 REQUIRE(state1_max_time == 10000);
             }
 
-            THEN("the function should return the input") {
+            THEN("the function should return the stored value") {
                 REQUIRE(returnFlag == 10);
             }
         }
@@ -262,7 +262,7 @@ SCENARIO("Set Duration Timer", "[duration timer]") {
                 REQUIRE(state2_max_duration == 10000);
             }
 
-            THEN("the function should return the input") {
+            THEN("the function should return the stored value") {
                 REQUIRE(returnFlag == 10);
             }
         }
@@ -316,7 +316,7 @@ SCENARIO("Set Stillness Timer", "[stillness timer]") {
                 REQUIRE(state3_max_stillness_time == 10000);
             }
 
-            THEN("the function should return the input") {
+            THEN("the function should return the stored value") {
                 REQUIRE(returnFlag == 10);
             }
         }
@@ -370,7 +370,7 @@ SCENARIO("Set Long Stillness Timer", "[long stillness timer]") {
                 REQUIRE(state3_max_long_stillness_time == 10000);
             }
 
-            THEN("the function should return the input") {
+            THEN("the function should return the stored value") {
                 REQUIRE(returnFlag == 10);
             }
         }
@@ -424,7 +424,7 @@ SCENARIO("Set INS Threshold", "[ins threshold]") {
                 REQUIRE(ins_threshold == 10);
             }
 
-            THEN("the function should return the input") {
+            THEN("the function should return the stored value") {
                 REQUIRE(returnFlag == 10);
             }
         }


### PR DESCRIPTION
Adding an additional entrance condition from state0 to state1.
- if the state0 timer exceeds a maximum timeout window, the firmware cannot enter state1
- this timer is reset when the paired door sensor switches from an open to a closed status
- the default value for the timeout will be 1 hour for uninitialized firmware
- a particle console function can be used to change the timeout value
- the console publish message will contain the current timer count for state 0 in `timer_status` along with the timeout in `window_size`

### Test Plan
___

- [x] Deploy firmware on test boron (with no memory of the window size) and connect to an INS radar
- [x] Use particle console to echo the initial value of the timeout and confirm that it is "3600"
- [x] Enter 10 in the function and confirm that it returns 10, echo again and confirm that it is still 10
- [x] View debug messages and confirm that the `window_size` reads `10000` and that the `timer_status` is increasing
- [x] Set the `intial_timer` to 30s
- [x] Open and close the paired door sensor and confirm that `timer_status` is reset
- [x] Physically shake the sensor to enter state1, after `timer_status` exceeds `window_size` stop shaking to return to state0, shake again to confirm that the sensor can no longer enter state1 
- [x] Set the `intial_timer` to 3s
- [x] Open and close the door sensor again, shake the sensor for 3s while within the 10s window and confirm that it enters state 2/3
- [x] Reset the sensor and echo the window size, confirming that it has remembered the 10s value

Oct 11th, 2024:

Ensure that the timer resets in these cases:
- [x] Open -> Missed Close -> Heartbeat + Closed
- [x] Closed -> Missed Open -> Close

Ensure that the timer does NOT reset in these cases:
- [x] Closed -> Heartbeat + Closed
- [x] Heartbeat + Closed -> Heartbeat + Closed
- [x] Unknown -> Heartbeat + Closed
