### PR TITLE
Implemented API call /api/message-clients (CU-w9bcb5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ the code was deployed.
 
 ## [Unreleased]
 
+### Added
+
+- API call /api/message-clients that sends a POSTed message to all clients with active sensors (CU-w9bcb5).
+
 ### Changed
 
 - README for AWS infrastructure changes (CU-860ra8f7q).
@@ -36,7 +40,6 @@ the code was deployed.
 - Unit tests for API authorize function (CU-8678uuvjm).
 - Added 'View Client' button to Internal Dashboard-Location page (CU-8678vn1r5).
 - GitHub Actions to deploy to AWS infrastructure on Production (CU-860ra8f7q).
-- API call /api/message-clients that sends a POSTed message to all clients with active sensors (CU-w9bcb5)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ the code was deployed.
 - Unit tests for API authorize function (CU-8678uuvjm).
 - Added 'View Client' button to Internal Dashboard-Location page (CU-8678vn1r5).
 - GitHub Actions to deploy to AWS infrastructure on Production (CU-860ra8f7q).
+- API call /api/message-clients that sends a POSTed message to all clients with active sensors (CU-w9bcb5)
 
 ### Fixed
 
@@ -30,7 +31,6 @@ the code was deployed.
 - "doorMissedFrequently" field to JSON data submitted by brave sensors that is sent to /api/heartbeat (CU-860rk8v2a).
 - Sentry log in the case that doorMissedFrequently is true in posted data from brave sensor (CU-860rk8v2a).
 - GitHub Actions to deploy to AWS infrastructure on Dev and Staging (CU-860ra8f7q).
-- API call /api/message-clients that sends a POSTed message to all clients with active sensors (CU-w9bcb5)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ the code was deployed.
 - "doorMissedFrequently" field to JSON data submitted by brave sensors that is sent to /api/heartbeat (CU-860rk8v2a)
 - Sentry log in the case that doorMissedFrequently is true in posted data from brave sensor (CU-860rk8v2a)
 - GitHub Actions to deploy to AWS infrastructure on Dev and Staging (CU-860ra8f7q).
+- API call /api/message-clients that sends a POSTed message to all clients with active sensors (CU-w9bcb5)
 
 ### Removed
 

--- a/server/api.js
+++ b/server/api.js
@@ -113,10 +113,11 @@ async function messageClients(req, res) {
           const twilioResponse = await twilioHelpers.sendTwilioMessage(phoneNumber, client.fromPhoneNumber, message)
 
           // keep track of which clients were contacted and not contacted
-          if (twilioResponse.ok) {
-            response.contacted.push({ id: client.id, displayName: client.displayName })
-          } else {
+          if (twilioResponse === undefined || twilioResponse.status === undefined || twilioResponse.status !== 'queued') {
             response.errors.push({ id: client.id, displayName: client.displayName })
+            helpers.log(`Failed to send Twilio message "${message}" to ${phoneNumber} from ${client.fromPhoneNumber}.`)
+          } else {
+            response.contacted.push({ id: client.id, displayName: client.displayName })
           }
         }
       }

--- a/server/api.js
+++ b/server/api.js
@@ -88,7 +88,7 @@ async function messageClients(req, res) {
       const message = req.body.message
       const response = {
         status: 'success',
-	message: message,
+        message,
         contacted: [],
         failed: [],
       }

--- a/server/api.js
+++ b/server/api.js
@@ -87,25 +87,25 @@ async function messageClients(req, res) {
       const clients = await db.getActiveClients()
       const message = req.body.message
 
-      for (const c of clients) {
-        // define phone_numbers as a Set to prevent duplicate numbers
-        const phone_numbers = new Set()
+      for (const client of clients) {
+        // define phoneNumbers as a Set to prevent duplicate numbers
+        const phoneNumbers = new Set()
 
-        // add responder, fallback, and heartbeat numbers to phone_numbers
-        c.responderPhoneNumbers.forEach(pn => {
-          phone_numbers.add(pn)
+        // add responder, fallback, and heartbeat numbers to phoneNumbers
+        client.responderPhoneNumbers.forEach(phoneNumber => {
+          phoneNumbers.add(phoneNumber)
         })
-        c.fallbackPhoneNumbers.forEach(pn => {
-          phone_numbers.add(pn)
+        client.fallbackPhoneNumbers.forEach(phoneNumber => {
+          phoneNumbers.add(phoneNumber)
         })
-        c.heartbeatPhoneNumbers.forEach(pn => {
-          phone_numbers.add(pn)
+        client.heartbeatPhoneNumbers.forEach(phoneNumber => {
+          phoneNumbers.add(phoneNumber)
         })
 
         // for each phone number of this client
-        for (const pn of phone_numbers) {
+        for (const phoneNumber of phoneNumbers) {
           // send SMS text message
-          twilioHelpers.sendTwilioMessage(pn, c.fromPhoneNumber, message)
+          await twilioHelpers.sendTwilioMessage(phoneNumber, client.fromPhoneNumber, message)
         }
       }
 

--- a/server/api.js
+++ b/server/api.js
@@ -92,9 +92,15 @@ async function messageClients(req, res) {
         const phone_numbers = new Set()
 
         // add responder, fallback, and heartbeat numbers to phone_numbers
-        for (const pn of c.responder_phone_numbers) phone_numbers.add(pn)
-        for (const pn of c.fallback_phone_numbers) phone_numbers.add(pn)
-        for (const pn of c.heartbeat_phone_numbers) phone_numbers.add(pn)
+        c.responderPhoneNumbers.forEach(pn => {
+          phone_numbers.add(pn)
+        })
+        c.fallbackPhoneNumbers.forEach(pn => {
+          phone_numbers.add(pn)
+        })
+        c.heartbeatPhoneNumbers.forEach(pn => {
+          phone_numbers.add(pn)
+        })
 
         // for each phone number of this client
         for (const pn of phone_numbers) {

--- a/server/db/db.js
+++ b/server/db/db.js
@@ -144,7 +144,7 @@ async function getClients(pgClient) {
       return null
     }
 
-    return await Promise.all(results.rows.map(r => createClientFromRow(r, pgClient)))
+    return await Promise.all(results.rows.map(r => createClientFromRow(r)))
   } catch (err) {
     helpers.log(err.toString())
   }
@@ -175,7 +175,7 @@ async function getActiveClients(pgClient) {
       return null
     }
 
-    return await Promise.all(results.rows.map(r => createClientFromRow(r, pgClient)))
+    return await Promise.all(results.rows.map(r => createClientFromRow(r)))
   } catch (err) {
     helpers.log(err.toString())
   }
@@ -916,7 +916,7 @@ async function updateClient(
 
     helpers.log(`Client '${displayName}' successfully updated`)
 
-    return await createClientFromRow(results.rows[0], pgClient)
+    return await createClientFromRow(results.rows[0])
   } catch (err) {
     helpers.log(err.toString())
   }

--- a/server/routes.js
+++ b/server/routes.js
@@ -27,7 +27,6 @@ function configureRoutes(app) {
   app.post('/login', dashboard.submitLogin)
 
   app.post('/api/heartbeat', vitals.validateHeartbeat, vitals.handleHeartbeat)
-  app.post('/api/message-clients', api.validateMessageClients, api.authorize, api.messageClients)
 
   app.post('/pa/create-sensor-location', pa.validateCreateSensorLocation, clickUpHelpers.clickUpChecker, pa.handleCreateSensorLocation)
   app.post('/pa/get-sensor-clients', pa.validateGetSensorClients, clickUpHelpers.clickUpChecker, pa.handleGetSensorClients)
@@ -35,6 +34,7 @@ function configureRoutes(app) {
 
   app.get('/api/sensors', api.validateGetAllSensors, api.authorize, api.getAllSensors)
   app.get('/api/sensors/:sensorId', api.validateGetSensor, api.authorize, api.getSensor)
+  app.post('/api/message-clients', api.validateMessageClients, api.authorize, api.messageClients)
 
   // TODO add the other routes
 }

--- a/server/routes.js
+++ b/server/routes.js
@@ -27,6 +27,7 @@ function configureRoutes(app) {
   app.post('/login', dashboard.submitLogin)
 
   app.post('/api/heartbeat', vitals.validateHeartbeat, vitals.handleHeartbeat)
+  app.post('/api/message-clients', api.validateMessageClients, api.authorize, api.messageClients)
 
   app.post('/pa/create-sensor-location', pa.validateCreateSensorLocation, clickUpHelpers.clickUpChecker, pa.handleCreateSensorLocation)
   app.post('/pa/get-sensor-clients', pa.validateGetSensorClients, clickUpHelpers.clickUpChecker, pa.handleGetSensorClients)

--- a/server/test/integration/apiTest/messageClientsTest.js
+++ b/server/test/integration/apiTest/messageClientsTest.js
@@ -80,7 +80,7 @@ describe('api.js integration tests: messageClients', () => {
         isSendingVitals: true,
       }),
     )
-    for (let i = 0; i < 4; i++) {
+    for (let i = 0; i < 4; i += 1) {
       testExpectResponse.push({
         to: testExpectPhoneNumbers[i],
         from: testFromPhoneNumber,
@@ -146,9 +146,9 @@ describe('api.js integration tests: messageClients', () => {
     )
 
     // create locations for all non-active clients
-    for (let i = 0; i < 3; i++) {
+    for (let i = 0; i < 3; i += 1) {
       testNotExpectResponse.push({
-        to: testNotExpectPhoneNumbers[i+1],
+        to: testNotExpectPhoneNumbers[i + 1],
         from: testFromPhoneNumber,
         clientId: nonActiveClients[i].id,
         clientDisplayName: nonActiveClients[i].displayName,

--- a/server/test/integration/apiTest/messageClientsTest.js
+++ b/server/test/integration/apiTest/messageClientsTest.js
@@ -158,7 +158,7 @@ describe('api.js integration tests: messageClients', () => {
     this.agent.close()
   })
 
-  describe('for a good request', () => {
+  describe('for a request that uses the correct PA API key', () => {
     it('should respond with status 200 (OK)', async () => {
       const response = await this.agent.post('/api/message-clients').send({ braveKey, message })
 
@@ -182,7 +182,7 @@ describe('api.js integration tests: messageClients', () => {
     })
   })
 
-  describe('for a bad request', () => {
+  describe('for a request that uses an incorrect PA API key', () => {
     it('should respond with status 401 (Unauthorized)', async () => {
       const response = await this.agent.post('/api/message-clients').send({ braveKey: badBraveKey, message })
 

--- a/server/test/integration/apiTest/messageClientsTest.js
+++ b/server/test/integration/apiTest/messageClientsTest.js
@@ -171,7 +171,7 @@ describe('api.js integration tests: messageClients', () => {
   describe('for a request that uses the correct PA API key, and where Twilio is operating correctly', () => {
     beforeEach(async () => {
       // stub twilioHelpers.sendTwilioMessage
-      sandbox.stub(twilioHelpers, 'sendTwilioMessage').returns({ ok: true })
+      sandbox.stub(twilioHelpers, 'sendTwilioMessage').returns({ status: 'queued' })
     })
 
     afterEach(async () => {
@@ -216,7 +216,7 @@ describe('api.js integration tests: messageClients', () => {
   describe('for a request that uses the correct PA API key, and where Twilio is not operating correctly', () => {
     beforeEach(async () => {
       // stub twilioHelpers.sendTwilioMessage
-      sandbox.stub(twilioHelpers, 'sendTwilioMessage').returns({ ok: false })
+      sandbox.stub(twilioHelpers, 'sendTwilioMessage').returns(undefined)
     })
 
     afterEach(async () => {

--- a/server/test/integration/apiTest/messageClientsTest.js
+++ b/server/test/integration/apiTest/messageClientsTest.js
@@ -1,0 +1,198 @@
+// Third-party dependencies
+const chai = require('chai')
+const chaiHttp = require('chai-http')
+const sinonChai = require('sinon-chai')
+const { afterEach, beforeEach, describe, it } = require('mocha')
+const sinon = require('sinon')
+
+// In-house dependencies
+const { factories, helpers, twilioHelpers } = require('brave-alert-lib')
+const { db, server } = require('../../../index')
+const { locationDBFactory } = require('../../../testingHelpers')
+
+chai.use(chaiHttp)
+chai.use(sinonChai)
+
+const expect = chai.expect
+const sandbox = sinon.createSandbox()
+const braveKey = helpers.getEnvVar('PA_API_KEY_PRIMARY')
+const badBraveKey = 'badbravekey'
+const message = 'Hello, world!'
+const testFromPhoneNumber = '+11234567890'
+// number of test phone numbers in both expect and not expect arrays
+const testExpectPhoneNumbers = ['+11111111111', '+12222222222', '+13333333333', '+14444444444']
+const testNotExpectPhoneNumbers = ['+15555555555', '+16666666666', '+17777777777', '+18888888888']
+
+describe('api.js integration tests: messageClients', () => {
+  beforeEach(async () => {
+    await db.clearTables()
+
+    // active clients
+    const activeClients = []
+
+    // has responder phone number
+    activeClients.push(
+      await factories.clientDBFactory(db, {
+        displayName: 'Test Client Responder',
+        responderPhoneNumbers: [testExpectPhoneNumbers[0]],
+        fallbackPhoneNumbers: [],
+        heartbeatPhoneNumbers: [],
+        fromPhoneNumber: testFromPhoneNumber,
+        isSendingAlerts: true,
+        isSendingVitals: true,
+      }),
+    )
+    // has fallback phone number
+    activeClients.push(
+      await factories.clientDBFactory(db, {
+        displayName: 'Test Client Fallback',
+        responderPhoneNumbers: [],
+        fallbackPhoneNumbers: [testExpectPhoneNumbers[1]],
+        heartbeatPhoneNumbers: [],
+        fromPhoneNumber: testFromPhoneNumber,
+        isSendingAlerts: true,
+        isSendingVitals: true,
+      }),
+    )
+    // has heartbeat phone number
+    activeClients.push(
+      await factories.clientDBFactory(db, {
+        displayName: 'Test Client Heartbeat',
+        responderPhoneNumbers: [],
+        fallbackPhoneNumbers: [],
+        heartbeatPhoneNumbers: [testExpectPhoneNumbers[2]],
+        fromPhoneNumber: testFromPhoneNumber,
+        isSendingAlerts: true,
+        isSendingVitals: true,
+      }),
+    )
+    // has duplicate phone numbers
+    activeClients.push(
+      await factories.clientDBFactory(db, {
+        displayName: 'Test Client Duplicates',
+        responderPhoneNumbers: [testExpectPhoneNumbers[3]],
+        fallbackPhoneNumbers: [testExpectPhoneNumbers[3]],
+        heartbeatPhoneNumbers: [testExpectPhoneNumbers[3]],
+        fromPhoneNumber: testFromPhoneNumber,
+        isSendingAlerts: true,
+        isSendingVitals: true,
+      }),
+    )
+
+    // create locations for all active clients
+    for (const client of activeClients) {
+      await locationDBFactory(db, {
+        locationid: `Location${client.id.substr(0, 8)}`,
+        displayName: `Location for ${client.displayName}`,
+        clientId: client.id,
+        isSendingAlerts: true,
+        isSendingVitals: true,
+      })
+    }
+
+    // non-active clients
+    const nonActiveClients = []
+
+    await factories.clientDBFactory(db, {
+      displayName: 'Test Client No Location',
+      responderPhoneNumbers: [testNotExpectPhoneNumbers[0]],
+      fallbackPhoneNumbers: [],
+      heartbeatPhoneNumbers: [],
+      fromPhoneNumber: testFromPhoneNumber,
+      isSendingAlerts: true,
+      isSendingVitals: true,
+    })
+    nonActiveClients.push(
+      await factories.clientDBFactory(db, {
+        displayName: "Test Client Don't Send Alerts",
+        responderPhoneNumbers: [],
+        fallbackPhoneNumbers: [testNotExpectPhoneNumbers[1]],
+        heartbeatPhoneNumbers: [],
+        fromPhoneNumber: testFromPhoneNumber,
+        isSendingAlerts: false,
+        isSendingVitals: true,
+      }),
+    )
+    nonActiveClients.push(
+      await factories.clientDBFactory(db, {
+        displayName: "Test Client Don't Send Vitals",
+        responderPhoneNumbers: [],
+        fallbackPhoneNumbers: [],
+        heartbeatPhoneNumbers: [testNotExpectPhoneNumbers[2]],
+        fromPhoneNumber: testFromPhoneNumber,
+        isSendingAlerts: true,
+        isSendingVitals: false,
+      }),
+    )
+    nonActiveClients.push(
+      await factories.clientDBFactory(db, {
+        displayName: "Test Client Don't Send",
+        responderPhoneNumbers: [testNotExpectPhoneNumbers[3]],
+        fallbackPhoneNumbers: [testNotExpectPhoneNumbers[3]],
+        heartbeatPhoneNumbers: [testNotExpectPhoneNumbers[3]],
+        fromPhoneNumber: testFromPhoneNumber,
+        isSendingAlerts: false,
+        isSendingVitals: false,
+      }),
+    )
+
+    // create locations for all non-active clients
+    for (const client of nonActiveClients) {
+      await locationDBFactory(db, {
+        locationid: `Location${client.id.substr(0, 8)}`,
+        displayName: `Location for ${client.displayName}`,
+        clientId: client.id,
+        isSendingAlerts: Math.round(Math.random()),
+        isSendingVitals: Math.round(Math.random()),
+      })
+    }
+
+    // stub twilioHelpers.sendTwilioMessage
+    sandbox.stub(twilioHelpers, 'sendTwilioMessage')
+    this.agent = chai.request.agent(server)
+  })
+
+  afterEach(async () => {
+    sandbox.restore()
+    await db.clearTables()
+    this.agent.close()
+  })
+
+  describe('for a good request', () => {
+    it('should respond with status 200 (OK)', async () => {
+      const response = await this.agent.post('/api/message-clients').send({ braveKey, message })
+
+      expect(response).to.have.status(200)
+    })
+
+    it('should message all active clients', async () => {
+      await this.agent.post('/api/message-clients').send({ braveKey, message })
+
+      testExpectPhoneNumbers.forEach(pn => {
+        expect(twilioHelpers.sendTwilioMessage).to.be.calledWith(pn, testFromPhoneNumber, message)
+      })
+    })
+
+    it('should not message any non-active clients', async () => {
+      await this.agent.post('/api/message-clients').send({ braveKey, message })
+
+      testNotExpectPhoneNumbers.forEach(pn => {
+        expect(twilioHelpers.sendTwilioMessage).to.not.be.calledWith(pn, testFromPhoneNumber, message)
+      })
+    })
+  })
+
+  describe('for a bad request', () => {
+    it('should respond with status 401 (Unauthorized)', async () => {
+      const response = await this.agent.post('/api/message-clients').send({ braveKey: badBraveKey, message })
+
+      expect(response).to.have.status(401)
+    })
+
+    it('should not message anyone', async () => {
+      await this.agent.post('/api/message-clients').send({ braveKey: badBraveKey, message })
+
+      expect(twilioHelpers.sendTwilioMessage).to.not.be.called
+    })
+  })
+})


### PR DESCRIPTION
This API call is for sending downtime messages or other things that responders should know about.

It works as follows:

For all clients that are sending vitals, sending alerts, and have at least one location that is sending vitals and sending alerts: send a Twilio message containing the message that was posted.
Requires proper submission of the Particle Accelerator API key (braveKey); this is because the API call is intended to be called from PA.

Upon successful submission of the API key, the server will respond with a JSON object containing information about contacted/failed clients:

```json
{
    "status": "success",
    "message": "This is the text message that was sent!",
    "contacted": [
        {
            "to": "+11111111111",
            "from": "+12222222222",
            "clientId": "01234567-89ab-cdef-0123-456789abcdef",
            "clientDisplayName": "Test Client"
        },
        {
            "to": "+13333333333",
            "from": "+14444444444",
            "clientId": "abcdef01-2345-6789-abcd-ef0123456789",
            "clientDisplayName": "Test Client"
        }
    ],
    "failed": []
}
```

Where `contacted` and `failed` are arrays of objects containing `to`, `from`, `clientId`, and `clientDisplayName` members.
All objects in `contacted` were successfully contacted; Twilio gave the status of "queued".
All objects in `failed` weren't successfully contacted; Twilio rejected the request, and did not queue the message.
Requests can fail for a variety of reasons, for example, an incorrect `from` phone number.

Additionally, upon failure to send a Twilio message, the following message will be logged internally; i.e., visible from the CloudWatch dashboard in AWS:

```
Failed to send Twilio message: {"to":"+11111111111","from":"+12222222222","clientId":"01234567-89ab-cdef-0123-456789abcdef","clientDisplayName":"Test Client"}.
```

This response information is intended to be displayed in the PA dashboard.

Test plan:
- [x] create several clients and locations on local database; test that this API call decides which clients to message properly
- [x] write integration tests to make sure /api/message-clients parses active clients properly
  - [x] for a request that uses the correct PA API key, and where Twilio is operating correctly
    - [x] should respond with status 200 (OK)
    - [x] should respond with the same message that was posted
    - [x] should attempt to message all active clients
    - [x] should not attempt to message any non-active clients
    - [x] should respond with contacted clients in the `contacted` field of the response body
    - [x] should respond with no clients in the `failed` field of the response body
  - [x] for a request that uses the correct PA API key, and where Twilio is not operating correctly
    - [x] should respond with status 200 (OK)
    - [x] should respond with the same message that was posted
    - [x] should attempt to message all active clients
    - [x] should not attempt to message any non-active clients
    - [x] should respond with no clients in the `contacted` field of the response body
    - [x] should respond with active clients in the `failed` field of the response body
  - [x] for a request that uses the incorrect PA API key
    - [x] should respond with status 401 (Unauthorized)
    - [x] should not message anyone
  - [x] for a request that does not provide any PA API key
    - [x] should respond with status 401 (Unauthorized)
    - [x] should not message anyone
- [x] use this API call on the development server and prove that it works properly with real Twilio API keys
- [x] run smoke test to ensure that this doesn't interfere with basic functionality of BraveSensor