### PR TITLE
Add view client button to location dashboard (CU-#8678vn1r5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ the code was deployed.
 
 ## [Unreleased]
 
+### Added
+
+- Added 'View Client' button to Internal Dashboard-Location page (CU-8678vn1r5)
+
+
 ## [9.7.0] - 2023-09-21
 
 ### Added

--- a/server/dashboard.js
+++ b/server/dashboard.js
@@ -268,6 +268,7 @@ async function renderLocationDetailsPage(req, res) {
       clients: clients.filter(client => client.isDisplayed),
       recentSessions: [],
       currentLocation,
+      clientid: currentLocation.client.id,
     }
 
     for (const recentSession of recentSessions) {

--- a/server/mustache-templates/locationsDashboard.mst
+++ b/server/mustache-templates/locationsDashboard.mst
@@ -21,6 +21,7 @@
             <h3>{{displayName}}</h3>
             
             <a href="/locations/{{locationid}}/edit" class="btn btn-secondary btn-sm" role="button">Edit Location</a>
+            <a href="/clients/{{clientid}}" class="btn btn-secondary btn-sm" role="button">View Client</a>
             <br>
             <div class="table-responsive">
                 <table class="table table-striped table-sm">


### PR DESCRIPTION
Currently when you select a location in the internal dashboard, there is no easy way to be directed back to the associated client. Added a "View Client" button in the location dashboard to remedy this. 

Test Plan: 

- [x]  Deploy to dev and select a client then location. Ensure _View Client_ button returns you to the location's client page.
- [x]  Run `npm test` to ensure nothing else was impacted by the change
- [x] Make sure Travis has passed