### PR TITLE
Fixed response object of /api/message-clients to match conventions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ the code was deployed.
 
 - API call /api/message-clients that sends a POSTed message to all clients with active sensors (CU-w9bcb5).
 
+### Fixed
+
+- Response object of /api/message-clients to match conventions described at the top of api.js.
+
 ## [9.10.0] - 2023-10-06
 
 ### Added

--- a/server/api.js
+++ b/server/api.js
@@ -9,7 +9,7 @@
  *  - Must return a JSON object containing the following keys:
  *    - status:   which will be either "success" or "error"
  *    - data:     the desired JSON object, if there is one
- *    - message:  a human-readable explaination of the error, if there was one and this is appropriate. Be careful
+ *    - message:  a human-readable explanation of the error, if there was one and this is appropriate. Be careful
  *                to not include anything that will give an attacker extra information
  */
 
@@ -88,9 +88,12 @@ async function messageClients(req, res) {
       const message = req.body.message
       const response = {
         status: 'success',
-        message,
-        contacted: [],
-        failed: [],
+        data: {
+          message,
+          contacted: [],
+          failed: [],
+        },
+        message: '',
       }
 
       for (const client of clients) {
@@ -122,11 +125,11 @@ async function messageClients(req, res) {
 
           // keep track of which clients were contacted and not contacted
           if (twilioResponse === undefined || twilioResponse.status === undefined || twilioResponse.status !== 'queued') {
-            response.failed.push(twilioTraceObject)
+            response.data.failed.push(twilioTraceObject)
             // log entire Twilio trace object
             helpers.log(`Failed to send Twilio message: ${JSON.stringify(twilioTraceObject)}.`)
           } else {
-            response.contacted.push(twilioTraceObject)
+            response.data.contacted.push(twilioTraceObject)
           }
         }
       }

--- a/server/test/integration/apiTest/messageClientsTest.js
+++ b/server/test/integration/apiTest/messageClientsTest.js
@@ -189,7 +189,8 @@ describe('api.js integration tests: messageClients', () => {
     it('should respond with the same message that was posted', async () => {
       const response = await this.agent.post('/api/message-clients').send({ braveKey, message })
 
-      expect(response.body.message).to.be.a('string').that.equals(message)
+      expect(response.body.data).to.not.be.undefined
+      expect(response.body.data.message).to.be.a('string').that.equals(message)
     })
 
     it('should attempt to message all active clients', async () => {
@@ -211,13 +212,15 @@ describe('api.js integration tests: messageClients', () => {
     it('should respond with contacted client information in the `contacted` field of the response body', async () => {
       const response = await this.agent.post('/api/message-clients').send({ braveKey, message })
 
-      expect(response.body.contacted).to.be.an('array').that.has.deep.members(testExpectResponse)
+      expect(response.body.data).to.not.be.undefined
+      expect(response.body.data.contacted).to.be.an('array').that.has.deep.members(testExpectResponse)
     })
 
     it('should respond with no clients in the `failed` field of the response body', async () => {
       const response = await this.agent.post('/api/message-clients').send({ braveKey, message })
 
-      expect(response.body.failed).to.be.an('array').that.is.empty
+      expect(response.body.data).to.not.be.undefined
+      expect(response.body.data.failed).to.be.an('array').that.is.empty
     })
   })
 
@@ -240,7 +243,8 @@ describe('api.js integration tests: messageClients', () => {
     it('should respond with the same message that was posted', async () => {
       const response = await this.agent.post('/api/message-clients').send({ braveKey, message })
 
-      expect(response.body.message).to.be.a('string').that.equal(message)
+      expect(response.body.data).to.not.be.undefined
+      expect(response.body.data.message).to.be.a('string').that.equal(message)
     })
 
     it('should attempt to message all active clients', async () => {
@@ -262,13 +266,15 @@ describe('api.js integration tests: messageClients', () => {
     it('should respond with no clients in the `contacted` field of the response body', async () => {
       const response = await this.agent.post('/api/message-clients').send({ braveKey, message })
 
-      expect(response.body.contacted).to.be.an('array').that.is.empty
+      expect(response.body.data).to.not.be.undefined
+      expect(response.body.data.contacted).to.be.an('array').that.is.empty
     })
 
     it('should respond with active clients in the `failed` field of the response body', async () => {
       const response = await this.agent.post('/api/message-clients').send({ braveKey, message })
 
-      expect(response.body.failed).to.be.an('array').that.has.deep.members(testExpectResponse)
+      expect(response.body.data).to.not.be.undefined
+      expect(response.body.data.failed).to.be.an('array').that.has.deep.members(testExpectResponse)
     })
   })
 


### PR DESCRIPTION
Upon porting this feature to the BraveButtons repository, I discovered that the response object returned by /api/message-clients does not match the conventions described at the top of the api.js file in this repository.

This PR does not change the functionality of this API request; it simply moves some of the response object under a `data` object. Please read the conventions information at the top of api.js for more information.

Test Plan:
- [x] Passes all previously created tests for /api/message-clients.
- [x] Returned response object matches the conventions outlined in api.js.