### PR TITLE
Deadlock bug fixes (CU-8678wudz8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ the code was deployed.
 
 ## [Unreleased]
 
+### Added
+- Return value when beginTransaction function fails to start and error handling to try and prevent deadlocks (CU-8678wudz8).
+
+### Removed 
+- Locks on unnecessary tables in beginTransaction function (CU-8678wudz8).
+
 ### Fixed
 
 - Specify 1 byte write into Door ID flash addresses, preventing erroneous overwrite of long stillness timer flash addresses (CU-8678xpmpu). 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ the code was deployed.
 ## [Unreleased]
 
 ### Changed 
-- database function getMostRecentSensorsVitalWithLocation to take in entire location as parameter instead of just the locationid (CU-8678wudz8).
+- Database function getMostRecentSensorsVitalWithLocation to take in entire location as parameter instead of just the locationid (CU-8678wudz8).
 
 ### Added
 - Return value when beginTransaction function fails to start and error handling to try and prevent deadlocks (CU-8678wudz8).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ the code was deployed.
 
 ## [Unreleased]
 
+### Changed 
+- database function getMostRecentSensorsVitalWithLocation to take in entire location as parameter instead of just the locationid (CU-8678wudz8).
+
 ### Added
 - Return value when beginTransaction function fails to start and error handling to try and prevent deadlocks (CU-8678wudz8).
 

--- a/server/BraveAlerterConfigurator.js
+++ b/server/BraveAlerterConfigurator.js
@@ -90,12 +90,8 @@ class BraveAlerterConfigurator {
     try {
       pgClient = await db.beginTransaction()
       if (pgClient === null) {
-        // If the beginTransaction function failed to start the transaction, retry it once more before logging an error
-        pgClient = await db.beginTransaction()
-        if (pgClient === null) {
-          helpers.logError(`alertSessionChangedCallback: Error starting transaction`)
-          return
-        }
+        helpers.logError(`alertSessionChangedCallback: Error starting transaction`)
+        return
       }
       session = await db.getSessionWithSessionId(alertSession.sessionId, pgClient)
 

--- a/server/BraveAlerterConfigurator.js
+++ b/server/BraveAlerterConfigurator.js
@@ -90,8 +90,12 @@ class BraveAlerterConfigurator {
     try {
       pgClient = await db.beginTransaction()
       if (pgClient === null) {
-        helpers.logError(`alertSessionChangedCallback: Error starting transaction`)
-        return
+        // If the beginTransaction function failed to start the transaction, retry it once more before logging an error
+        pgClient = await db.beginTransaction()
+        if (pgClient === null) {
+          helpers.logError(`alertSessionChangedCallback: Error starting transaction`)
+          return
+        }
       }
       session = await db.getSessionWithSessionId(alertSession.sessionId, pgClient)
 

--- a/server/db/db.js
+++ b/server/db/db.js
@@ -71,6 +71,7 @@ async function beginTransaction() {
     if (pgClient) {
       try {
         await this.rollbackTransaction(pgClient)
+        return null
       } catch (err) {
         helpers.logError(`beginTransaction: Error rolling back the errored transaction: ${err}`)
       }

--- a/server/db/db.js
+++ b/server/db/db.js
@@ -1159,16 +1159,16 @@ async function getRecentSensorsVitalsWithClientId(clientId, pgClient) {
   return []
 }
 
-async function getMostRecentSensorsVitalWithLocationid(locationid, pgClient) {
+async function getMostRecentSensorsVitalWithLocation(location, pgClient) {
   try {
     const results = await helpers.runQuery(
-      'getMostRecentSensorsVitalWithLocationid',
+      'getMostRecentSensorsVitalWithLocation',
       `
       SELECT *
       FROM sensors_vitals_cache
       WHERE locationid = $1
       `,
-      [locationid],
+      [location.locationid],
       pool,
       pgClient,
     )
@@ -1177,7 +1177,7 @@ async function getMostRecentSensorsVitalWithLocationid(locationid, pgClient) {
       return null
     }
 
-    const allLocations = await getLocations(pgClient)
+    const allLocations = [location]
     return createSensorsVitalFromRow(results.rows[0], allLocations)
   } catch (err) {
     helpers.log(err.toString())
@@ -1508,7 +1508,7 @@ module.exports = {
   getLocations,
   getLocationsFromAlertApiKey,
   getLocationsFromClientId,
-  getMostRecentSensorsVitalWithLocationid,
+  getMostRecentSensorsVitalWithLocation,
   getMostRecentSessionWithLocationid,
   getMostRecentSessionWithPhoneNumbers,
   getNewNotificationsCountByAlertApiKey,

--- a/server/db/db.js
+++ b/server/db/db.js
@@ -1181,6 +1181,7 @@ async function getMostRecentSensorsVitalWithLocationid(locationid, pgClient) {
     return createSensorsVitalFromRow(results.rows[0], allLocations)
   } catch (err) {
     helpers.log(err.toString())
+    return null
   }
 }
 

--- a/server/db/db.js
+++ b/server/db/db.js
@@ -65,7 +65,7 @@ async function beginTransaction() {
 
     await pgClient.query('BEGIN')
 
-    await pgClient.query('LOCK TABLE clients, notifications, sessions, locations, sensors_vitals, sensors_vitals_cache')
+    await pgClient.query('LOCK TABLE clients, sessions, locations')
   } catch (e) {
     helpers.logError(`Error running the beginTransaction query: ${e}`)
     if (pgClient) {

--- a/server/test/integration/vitalsTest/handleHeartbeatTest.js
+++ b/server/test/integration/vitalsTest/handleHeartbeatTest.js
@@ -9,6 +9,7 @@ const sinon = require('sinon')
 const { factories, helpers } = require('brave-alert-lib')
 const { braveAlerter, db, server } = require('../../../index')
 const { locationDBFactory, sensorsVitalDBFactory } = require('../../../testingHelpers')
+// const { sendLowBatteryAlert } = require('../../../vitals')
 
 chai.use(chaiHttp)
 chai.use(sinonChai)
@@ -365,6 +366,7 @@ describe('vitals.js integration tests: handleHeartbeat', () => {
       sandbox.stub(braveAlerter, 'startAlertSession')
       sandbox.stub(braveAlerter, 'sendSingleAlert')
       sandbox.spy(helpers, 'logSentry')
+      sandbox.spy(helpers, 'logError')
       sandbox.stub(db, 'logSensorsVital')
     })
 
@@ -401,6 +403,12 @@ describe('vitals.js integration tests: handleHeartbeat', () => {
     it('should call sendSingleAlert', async () => {
       await lowBatteryHeartbeat(radar_coreID)
       expect(braveAlerter.sendSingleAlert).to.be.called
+    })
+
+    it('should log an error if pgClient is null in sendLowBatteryAlert', async () => {
+      sandbox.stub(db, 'beginTransaction').returns(null)
+      await lowBatteryHeartbeat(radar_coreID)
+      expect(helpers.logError).to.be.calledWith(`sendLowBatteryAlert: Error starting transaction`)
     })
   })
 

--- a/server/test/integration/vitalsTest/handleHeartbeatTest.js
+++ b/server/test/integration/vitalsTest/handleHeartbeatTest.js
@@ -9,7 +9,6 @@ const sinon = require('sinon')
 const { factories, helpers } = require('brave-alert-lib')
 const { braveAlerter, db, server } = require('../../../index')
 const { locationDBFactory, sensorsVitalDBFactory } = require('../../../testingHelpers')
-// const { sendLowBatteryAlert } = require('../../../vitals')
 
 chai.use(chaiHttp)
 chai.use(sinonChai)

--- a/server/test/unit/vitalsTest/checkHeartbeatTest.js
+++ b/server/test/unit/vitalsTest/checkHeartbeatTest.js
@@ -65,7 +65,7 @@ describe('vitals.js unit tests: checkHeartbeat', () => {
       sandbox.stub(db, 'getLocations').returns([this.testLocation])
 
       sandbox
-        .stub(db, 'getMostRecentSensorsVitalWithLocationid')
+        .stub(db, 'getMostRecentSensorsVitalWithLocation')
         .returns(sensorsVitalFactory({ createdAt: excessiveRadarDate, doorLastSeenAt: notExcessiveDoorDate, resetReason }))
 
       await vitals.checkHeartbeat()
@@ -107,7 +107,7 @@ describe('vitals.js unit tests: checkHeartbeat', () => {
       sandbox.stub(db, 'getLocations').returns([this.testLocation])
 
       sandbox
-        .stub(db, 'getMostRecentSensorsVitalWithLocationid')
+        .stub(db, 'getMostRecentSensorsVitalWithLocation')
         .returns(sensorsVitalFactory({ createdAt: excessiveRadarDate, doorLastSeenAt: notExcessiveDoorDate, resetReason }))
 
       await vitals.checkHeartbeat()
@@ -145,7 +145,7 @@ describe('vitals.js unit tests: checkHeartbeat', () => {
       sandbox.stub(db, 'getLocations').returns([this.testLocation])
 
       sandbox
-        .stub(db, 'getMostRecentSensorsVitalWithLocationid')
+        .stub(db, 'getMostRecentSensorsVitalWithLocation')
         .returns(sensorsVitalFactory({ createdAt: excessiveRadarDate, doorLastSeenAt: notExcessiveDoorDate, resetReason }))
 
       await vitals.checkHeartbeat()
@@ -186,7 +186,7 @@ describe('vitals.js unit tests: checkHeartbeat', () => {
       sandbox.stub(db, 'getLocations').returns([this.testLocation])
 
       sandbox
-        .stub(db, 'getMostRecentSensorsVitalWithLocationid')
+        .stub(db, 'getMostRecentSensorsVitalWithLocation')
         .returns(sensorsVitalFactory({ createdAt: notExcessiveRadarDate, doorLastSeenAt: excessiveDoorDate, resetReason }))
 
       await vitals.checkHeartbeat()
@@ -232,7 +232,7 @@ describe('vitals.js unit tests: checkHeartbeat', () => {
       sandbox.stub(db, 'getLocations').returns([this.testLocation])
 
       sandbox
-        .stub(db, 'getMostRecentSensorsVitalWithLocationid')
+        .stub(db, 'getMostRecentSensorsVitalWithLocation')
         .returns(sensorsVitalFactory({ createdAt: notExcessiveRadarDate, doorLastSeenAt: notExcessiveDoorDate, resetReason }))
 
       await vitals.checkHeartbeat()
@@ -278,7 +278,7 @@ describe('vitals.js unit tests: checkHeartbeat', () => {
       sandbox.stub(db, 'getLocations').returns([this.testLocation])
 
       sandbox
-        .stub(db, 'getMostRecentSensorsVitalWithLocationid')
+        .stub(db, 'getMostRecentSensorsVitalWithLocation')
         .returns(sensorsVitalFactory({ createdAt: excessiveRadarDate, doorLastSeenAt: notExcessiveDoorDate, resetReason }))
 
       await vitals.checkHeartbeat()
@@ -318,7 +318,7 @@ describe('vitals.js unit tests: checkHeartbeat', () => {
       })
       sandbox.stub(db, 'getLocations').returns([this.testLocation])
 
-      sandbox.stub(db, 'getMostRecentSensorsVitalWithLocationid').returns({ createdAt: excessiveRadarDate, resetReason })
+      sandbox.stub(db, 'getMostRecentSensorsVitalWithLocation').returns({ createdAt: excessiveRadarDate, resetReason })
 
       await vitals.checkHeartbeat()
     })

--- a/server/vitals.js
+++ b/server/vitals.js
@@ -88,7 +88,7 @@ async function checkHeartbeat() {
     }
 
     try {
-      const sensorsVital = await db.getMostRecentSensorsVitalWithLocationid(location.locationid)
+      const sensorsVital = await db.getMostRecentSensorsVitalWithLocation(location)
 
       if (sensorsVital) {
         const radarDelayInSeconds = differenceInSeconds(currentDBTime, sensorsVital.createdAt)
@@ -240,7 +240,7 @@ async function handleHeartbeat(req, res) {
           const doorMissedFrequently = message.doorMissedFrequently
           const resetReason = message.resetReason
           const stateTransitionsArray = message.states.map(convertStateArrayToObject)
-          const mostRecentSensorVitals = await db.getMostRecentSensorsVitalWithLocationid(location.locationid)
+          const mostRecentSensorVitals = await db.getMostRecentSensorsVitalWithLocation(location)
 
           let doorLastSeenAt
           let isTamperedFlag

--- a/server/vitals.js
+++ b/server/vitals.js
@@ -162,6 +162,10 @@ async function sendLowBatteryAlert(locationid) {
     const timeoutInMillis = parseInt(helpers.getEnvVar('LOW_BATTERY_ALERT_TIMEOUT'), 10) * 1000
 
     pgClient = await db.beginTransaction()
+    if (pgClient === null) {
+      helpers.logError(`sendLowBatteryAlert: Error starting transaction`)
+      return
+    }
     const location = await db.getLocationData(locationid, pgClient)
 
     if (


### PR DESCRIPTION
Made some small changes to see if they will have any effect on the increased deadlock errors that have been coming in. I will monitor the Sentry error logs after these changes are deployed, then revisit to amend/update. Changes are outlined below and in the clickup task comments. I don't _think_ I need to add new tests for these changes, but let me know if you think otherwise.

**vitals.js**
- Added error handling to `sendLowBatteryAlert()` to stop subsequent db queries  

**BraveAlerterConfigurator.js**
- Added retry to `alertSessionChangedCallback()` per convo with Theresa 
- Retrying `beginTransaction` as we only have on shot at this function working (vs heartbeat that comes in often and can capture data the next time its called) 
- Retry has no time delay as of right now, but could be something to look into later

**db.js**
- Removed lock on tables that are not used in the functions that call beginTransaction
- Another solution could be to have `beginTransaction` take in a parameter that represents the exact tables needed to be locked - currently I don't think is necessary unless `beginTransaction` starts to gets used in more functions
- Added explicit return values to `beginTransaction` and `getMostRecentSensorsVitalWithLocationid`in their catch blocks
- Update parameter in `getMostRecentSensorsVitalWithLocationid()` so that it takes the whole `location` object INSTEAD of just `locationid` (since the location info is already available when this function gets called) . This would eliminate the need to call getLocations reducing the use of this db resource, and ideally reducing chance of deadlock.
   - Update the function name to `getMostRecentSensorsVitalWithLocation` to reflect this change

**checkHeartbeatTest.js**
- Update function name from `getMostRecentSensorsVitalWithLocationid` to `getMostRecentSensorsVitalWithLocation`

Test Plan:
- [x] Test case in `checkHeartbeatTest.js` passes: Error is logged from the `SendLowBatteryAlert` function when `db.beginTransaction` returns null 
- [x] Ensure Travis is passing
- [x] Deploy to Dev with no issues
- [x] Smoke test passes 
