### PR TITLE
Upgrade axios from 0.21.4 to 1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ the code was deployed.
 - PA API routes /pa/create-sensor-location, /pa/get-sensor-clients, /pa/sensor-twilio-number to use googleHelpers.paAuthorize instead of clickUpHelpers.clickUpChecker (CU-8679128c8).
 - Upgraded `brave-alert-lib` to v10.3.0 (CU-8679128c8).
 - Unit tests for api.authorize function to follow conventions in other testing files.
+- Upgraded `axios` from 0.21.4 to 1.6.0.
 
 ## [10.1.1] - 2023-11-15
 

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@sentry/node": "^6.2.5",
         "@sentry/tracing": "^6.2.5",
-        "axios": "^0.21.2",
+        "axios": "^1.6.0",
         "brave-alert-lib": "https://github.com/bravetechnologycoop/brave-alert-lib#v10.3.0",
         "cookie-parser": "^1.4.5",
         "cors": "^2.8.5",
@@ -1455,11 +1455,13 @@
       }
     },
     "node_modules/axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.2.tgz",
+      "integrity": "sha512-7i24Ri4pmDRfJTR7LDBhsOTtcm+9kjX5WiY1X3wIisx6G9So3pfMkEiU7emUBe46oceVImccTEM3k6C5dbVW8A==",
       "dependencies": {
-        "follow-redirects": "^1.14.0"
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/axobject-query": {
@@ -1621,6 +1623,14 @@
         "google-auth-library": "^9.2.0",
         "luxon": "^2.5.2",
         "twilio": "^4.7.1"
+      }
+    },
+    "node_modules/brave-alert-lib/node_modules/axios": {
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "dependencies": {
+        "follow-redirects": "^1.14.0"
       }
     },
     "node_modules/browser-stdout": {
@@ -5995,6 +6005,11 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/punycode": {
       "version": "2.3.0",

--- a/server/package.json
+++ b/server/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@sentry/node": "^6.2.5",
     "@sentry/tracing": "^6.2.5",
-    "axios": "^0.21.2",
+    "axios": "^1.6.0",
     "brave-alert-lib": "https://github.com/bravetechnologycoop/brave-alert-lib#v10.3.0",
     "cookie-parser": "^1.4.5",
     "cors": "^2.8.5",


### PR DESCRIPTION
`axios` must be upgraded because of a critical security vulnerability raised by `npm`.

This is a breaking version change, so this PR outlines the additional testing that I have done to ensure the functionality of this repository isn't broken by upgrading `axios`.

Test Plan:
- [x] Minor review of the breaking changes in this version change (nothing that we use!)
- [x] Passes all test cases
- [x] Smoke test is successful 