### PR TITLE
Add Route to Check the Database Connection (CU-86dqkw7ef)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ the code was deployed.
 
 ## [Unreleased]
 
+## Added
+
+- PA route /pa/check-database-connection to check if database connection is working as expected (CU-86dqkw7ef).
+
 ## [10.3.0] - 2023-12-07
 
 ### Added

--- a/server/db/db.js
+++ b/server/db/db.js
@@ -1252,28 +1252,6 @@ async function createNotification(clientId, subject, body, isAcknowledged, pgCli
   }
 }
 
-async function getFirstClient(pgClient) {
-  try {
-    const results = await helpers.runQuery(
-      'getFirstClient',
-      `
-      SELECT id
-      FROM clients
-      LIMIT 1
-      `,
-      [],
-      pool,
-      pgClient,
-    )
-    if (results === undefined) {
-      return null
-    }
-    return results.rows
-  } catch (err) {
-    helpers.log(err.toString())
-  }
-}
-
 async function clearSensorsVitals(pgClient) {
   if (!helpers.isTestEnvironment()) {
     helpers.log('warning - tried to clear sensors vitals table outside of a test environment!')
@@ -1563,5 +1541,4 @@ module.exports = {
   updateLocation,
   updateLowBatteryAlertTime,
   updateSentAlerts,
-  getFirstClient,
 }

--- a/server/db/db.js
+++ b/server/db/db.js
@@ -1265,13 +1265,12 @@ async function getFirstClient(pgClient) {
       pool,
       pgClient,
     )
-    if (results === undefined || results.rows.length === 0) {
+    if (results === undefined) {
       return null
     }
     return results.rows
   } catch (err) {
     helpers.log(err.toString())
-    return null
   }
 }
 

--- a/server/db/db.js
+++ b/server/db/db.js
@@ -1252,6 +1252,29 @@ async function createNotification(clientId, subject, body, isAcknowledged, pgCli
   }
 }
 
+async function getFirstClient(pgClient) {
+  try {
+    const results = await helpers.runQuery(
+      'getFirstClient',
+      `
+      SELECT id
+      FROM clients
+      LIMIT 1
+      `,
+      [],
+      pool,
+      pgClient,
+    )
+    if (results === undefined || results.rows.length === 0) {
+      return null
+    }
+    return results.rows
+  } catch (err) {
+    helpers.log(err.toString())
+    return null
+  }
+}
+
 async function clearSensorsVitals(pgClient) {
   if (!helpers.isTestEnvironment()) {
     helpers.log('warning - tried to clear sensors vitals table outside of a test environment!')
@@ -1541,4 +1564,5 @@ module.exports = {
   updateLocation,
   updateLowBatteryAlertTime,
   updateSentAlerts,
+  getFirstClient,
 }

--- a/server/db/db.js
+++ b/server/db/db.js
@@ -13,8 +13,7 @@ const pool = new pg.Pool({
   user: helpers.getEnvVar('PG_USER'),
   database: helpers.getEnvVar('PG_DATABASE'),
   password: helpers.getEnvVar('PG_PASSWORD'),
-  // ssl: { rejectUnauthorized: false },
-  ssl: false,
+  ssl: { rejectUnauthorized: false },
 })
 
 // 1114 is OID for timestamp in Postgres

--- a/server/pa.js
+++ b/server/pa.js
@@ -219,12 +219,8 @@ async function handleCheckDatabaseConnection(req, res) {
 
     if (paApiKeys.includes(braveAPIKey)) {
       try {
-        const client = await db.getFirstClient()
-        if (client !== null) {
-          res.status(200).send({ message: 'success' })
-        } else {
-          res.status(500).send({ message: 'Error in Database Access' })
-        }
+        await db.getCurrentTime()
+        res.status(200).send({ message: 'success' })
       } catch (err) {
         helpers.logError(err)
         res.status(500).send({ message: 'Error in Database Access' })

--- a/server/pa.js
+++ b/server/pa.js
@@ -223,7 +223,6 @@ async function handleCheckDatabaseConnection(req, res) {
         res.status(200).send({ message: 'success' })
       } catch (err) {
         helpers.logError(err)
-        helpers.logSentry(err)
         res.status(503).send({ message: 'Error in Database Access' })
       }
     } else {

--- a/server/pa.js
+++ b/server/pa.js
@@ -219,11 +219,12 @@ async function handleCheckDatabaseConnection(req, res) {
 
     if (paApiKeys.includes(braveAPIKey)) {
       try {
-        await db.getCurrentTime()
+        await db.getCurrentTimeForHealthCheck()
         res.status(200).send({ message: 'success' })
       } catch (err) {
         helpers.logError(err)
-        res.status(500).send({ message: 'Error in Database Access' })
+        helpers.logSentry(err)
+        res.status(503).send({ message: 'Error in Database Access' })
       }
     } else {
       res.status(401).send({ message: 'Invalid API Key' })

--- a/server/routes.js
+++ b/server/routes.js
@@ -35,6 +35,7 @@ function configureRoutes(app) {
   app.post('/pa/get-sensor-clients', pa.validateGetSensorClients, googleHelpers.paAuthorize, pa.handleGetSensorClients)
   app.post('/pa/sensor-twilio-number', pa.validateSensorPhoneNumber, googleHelpers.paAuthorize, pa.handleSensorPhoneNumber)
   app.post('/pa/message-clients', pa.validateMessageClients, googleHelpers.paAuthorize, pa.handleMessageClients)
+  app.post('/pa/check-database-connection', pa.validateCheckDatabaseConnection, googleHelpers.paAuthorize, pa.handleCheckDatabaseConnection)
 
   app.get('/api/sensors', api.validateGetAllSensors, api.authorize, api.getAllSensors)
   app.get('/api/sensors/:sensorId', api.validateGetSensor, api.authorize, api.getSensor)

--- a/server/routes.js
+++ b/server/routes.js
@@ -35,7 +35,7 @@ function configureRoutes(app) {
   app.post('/pa/get-sensor-clients', pa.validateGetSensorClients, googleHelpers.paAuthorize, pa.handleGetSensorClients)
   app.post('/pa/sensor-twilio-number', pa.validateSensorPhoneNumber, googleHelpers.paAuthorize, pa.handleSensorPhoneNumber)
   app.post('/pa/message-clients', pa.validateMessageClients, googleHelpers.paAuthorize, pa.handleMessageClients)
-  app.post('/pa/check-database-connection', pa.validateCheckDatabaseConnection, googleHelpers.paAuthorize, pa.handleCheckDatabaseConnection)
+  app.post('/pa/health', pa.validateCheckDatabaseConnection, googleHelpers.paAuthorize, pa.handleCheckDatabaseConnection)
 
   app.get('/api/sensors', api.validateGetAllSensors, api.authorize, api.getAllSensors)
   app.get('/api/sensors/:sensorId', api.validateGetSensor, api.authorize, api.getSensor)

--- a/server/test/unit/paTest/handleCheckDatabaseConnection.js
+++ b/server/test/unit/paTest/handleCheckDatabaseConnection.js
@@ -1,0 +1,91 @@
+// Third-party dependencies
+const { expect, use } = require('chai')
+const { describe, it } = require('mocha')
+const sinon = require('sinon')
+const sinonChai = require('sinon-chai')
+
+// In-house dependencies
+const { helpers } = require('brave-alert-lib')
+const { mockResponse } = require('../../../testingHelpers')
+const pa = require('../../../pa')
+const db = require('../../../db/db')
+
+const testGoogleIdToken = 'google-id-token'
+const braveKey = helpers.getEnvVar('PA_API_KEY_PRIMARY')
+
+use(sinonChai)
+const sandbox = sinon.createSandbox()
+
+describe('pa.js unit tests: handleCheckDatabaseConnection', () => {
+  beforeEach(() => {
+    this.res = mockResponse(sandbox)
+    sandbox.spy(helpers, 'logError')
+  })
+
+  afterEach(() => {
+    sandbox.restore()
+  })
+
+  describe('for a valid request where the database function successfully returns a client', () => {
+    beforeEach(async () => {
+      sandbox.stub(db, 'getFirstClient').returns([{ id: '1', displayName: 'Fake Client' }])
+      await pa.handleCheckDatabaseConnection(
+        {
+          body: { braveKey, googleIdToken: testGoogleIdToken },
+        },
+        this.res,
+      )
+    })
+    it('should respond with status 200', () => {
+      expect(this.res.status).to.be.calledWith(200)
+    })
+  })
+
+  describe('for an request with an invalid braveKey', () => {
+    beforeEach(async () => {
+      sandbox.stub(db, 'getFirstClient')
+      await pa.handleCheckDatabaseConnection(
+        {
+          body: { braveKey: 'invalidKey', googleIdToken: testGoogleIdToken },
+        },
+        this.res,
+      )
+    })
+    it('should respond with status 401', () => {
+      expect(this.res.status).to.be.calledWith(401)
+    })
+  })
+
+  describe('for a valid request where an error occurs during database access', () => {
+    beforeEach(async () => {
+      sandbox.stub(db, 'getFirstClient').rejects(new Error('fake error'))
+      await pa.handleCheckDatabaseConnection(
+        {
+          body: { braveKey, googleIdToken: testGoogleIdToken },
+        },
+        this.res,
+      )
+    })
+    it('should log the error', () => {
+      expect(helpers.logError).to.be.called
+    })
+    it('should respond with status 500', () => {
+      expect(this.res.status).to.be.calledWith(500)
+    })
+  })
+
+  describe('for a valid request where the database function returns null', () => {
+    beforeEach(async () => {
+      sandbox.stub(db, 'getFirstClient').returns(null)
+      await pa.handleCheckDatabaseConnection(
+        {
+          body: { braveKey, googleIdToken: testGoogleIdToken },
+        },
+        this.res,
+      )
+    })
+    it('should respond with status 500', () => {
+      expect(this.res.status).to.be.calledWith(500)
+    })
+  })
+})

--- a/server/test/unit/paTest/handleCheckDatabaseConnectionTest.js
+++ b/server/test/unit/paTest/handleCheckDatabaseConnectionTest.js
@@ -28,6 +28,7 @@ describe('pa.js unit tests: handleCheckDatabaseConnection', () => {
 
   describe('for a valid request where the database function successfully returns a client', () => {
     beforeEach(async () => {
+      sandbox.stub(db, 'getCurrentTimeForHealthCheck').returns('2023-12-11 12:34:56.789+00')
       await pa.handleCheckDatabaseConnection(
         {
           body: { braveKey, googleIdToken: testGoogleIdToken },
@@ -42,6 +43,7 @@ describe('pa.js unit tests: handleCheckDatabaseConnection', () => {
 
   describe('for an request with an invalid braveKey', () => {
     beforeEach(async () => {
+      sandbox.stub(db, 'getCurrentTimeForHealthCheck')
       await pa.handleCheckDatabaseConnection(
         {
           body: { braveKey: 'invalidKey', googleIdToken: testGoogleIdToken },
@@ -56,7 +58,7 @@ describe('pa.js unit tests: handleCheckDatabaseConnection', () => {
 
   describe('for a valid request where an error occurs during database access', () => {
     beforeEach(async () => {
-      sandbox.stub(db, 'getCurrentTime').rejects(new Error('fake error'))
+      sandbox.stub(db, 'getCurrentTimeForHealthCheck').rejects(new Error('fake error'))
       await pa.handleCheckDatabaseConnection(
         {
           body: { braveKey, googleIdToken: testGoogleIdToken },
@@ -67,8 +69,8 @@ describe('pa.js unit tests: handleCheckDatabaseConnection', () => {
     it('should log the error', () => {
       expect(helpers.logError).to.be.called
     })
-    it('should respond with status 500', () => {
-      expect(this.res.status).to.be.calledWith(500)
+    it('should respond with status 503', () => {
+      expect(this.res.status).to.be.calledWith(503)
     })
   })
 })

--- a/server/test/unit/paTest/handleCheckDatabaseConnectionTest.js
+++ b/server/test/unit/paTest/handleCheckDatabaseConnectionTest.js
@@ -66,7 +66,7 @@ describe('pa.js unit tests: handleCheckDatabaseConnection', () => {
         this.res,
       )
     })
-    it.only('should log the error', () => {
+    it('should log the error', () => {
       expect(helpers.logError).to.be.called
     })
     it('should respond with status 500', () => {

--- a/server/test/unit/paTest/handleCheckDatabaseConnectionTest.js
+++ b/server/test/unit/paTest/handleCheckDatabaseConnectionTest.js
@@ -66,7 +66,7 @@ describe('pa.js unit tests: handleCheckDatabaseConnection', () => {
         this.res,
       )
     })
-    it('should log the error', () => {
+    it.only('should log the error', () => {
       expect(helpers.logError).to.be.called
     })
     it('should respond with status 500', () => {

--- a/server/test/unit/paTest/handleCheckDatabaseConnectionTest.js
+++ b/server/test/unit/paTest/handleCheckDatabaseConnectionTest.js
@@ -28,7 +28,6 @@ describe('pa.js unit tests: handleCheckDatabaseConnection', () => {
 
   describe('for a valid request where the database function successfully returns a client', () => {
     beforeEach(async () => {
-      sandbox.stub(db, 'getFirstClient').returns([{ id: '1', displayName: 'Fake Client' }])
       await pa.handleCheckDatabaseConnection(
         {
           body: { braveKey, googleIdToken: testGoogleIdToken },
@@ -43,7 +42,6 @@ describe('pa.js unit tests: handleCheckDatabaseConnection', () => {
 
   describe('for an request with an invalid braveKey', () => {
     beforeEach(async () => {
-      sandbox.stub(db, 'getFirstClient')
       await pa.handleCheckDatabaseConnection(
         {
           body: { braveKey: 'invalidKey', googleIdToken: testGoogleIdToken },
@@ -58,7 +56,7 @@ describe('pa.js unit tests: handleCheckDatabaseConnection', () => {
 
   describe('for a valid request where an error occurs during database access', () => {
     beforeEach(async () => {
-      sandbox.stub(db, 'getFirstClient').rejects(new Error('fake error'))
+      sandbox.stub(db, 'getCurrentTime').rejects(new Error('fake error'))
       await pa.handleCheckDatabaseConnection(
         {
           body: { braveKey, googleIdToken: testGoogleIdToken },
@@ -68,21 +66,6 @@ describe('pa.js unit tests: handleCheckDatabaseConnection', () => {
     })
     it('should log the error', () => {
       expect(helpers.logError).to.be.called
-    })
-    it('should respond with status 500', () => {
-      expect(this.res.status).to.be.calledWith(500)
-    })
-  })
-
-  describe('for a valid request where the database function returns null', () => {
-    beforeEach(async () => {
-      sandbox.stub(db, 'getFirstClient').returns(null)
-      await pa.handleCheckDatabaseConnection(
-        {
-          body: { braveKey, googleIdToken: testGoogleIdToken },
-        },
-        this.res,
-      )
     })
     it('should respond with status 500', () => {
       expect(this.res.status).to.be.calledWith(500)


### PR DESCRIPTION
## PA Route - Checking Database Connection
This PR is part of the broader Clickup task to create a system status page in PA. These changes include creating a route to check if the BraveSensors database connection is working as expected (by running one simple db query). PA will hit this route with a `googleIdToken` and `braveKey`. Upon getting the response, PA will  display a green icon if the connection is working or a red icon if it is not. 

### Test Plan:
- Unit Test for `pa.handleCheckDatabaseConnection`
   - [x] Valid request with successful database connection
   - [x] Request with invalid braveKey
   - [x] Valid request with database error
- Other Testing
   - [x] Test PA route with local environment where server is working but database is not connnected (status 503)
   - [x] Travis Passes
   - [x] Deploy to Dev - Test with Postman
      - [x] Valid API Key & GoogleIdToken
      - [x] Invalid API Key & valid GoogleIdToken
      - [x] Valid API Key & invalid GoogleIdToken
   - [x] Deploy to Dev - Smoketest
   - [x] Deploy to Dev - test route is working with PA