### PR TITLE
Allow Duration Alerts to Repeat (CU-8678tmmew)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ the code was deployed.
 
 ## [Unreleased]
 
+### Added
+
+- Allow Duration alerts to repeat. The duration timer is reset after a duration alert is triggered (CU-8678tmmew).
+
 ## [10.6.0] - 2024-01-23
 
 ### Added
@@ -18,7 +22,6 @@ the code was deployed.
 - `number_of_alerts` integer column to the sessions table (CU-860r8k57h).
 - Chatbot flow to reset a sensor if the `number_of_alerts` in a session meets or exceeds the threshold `SESSION_NUMBER_OF_ALERTS_TO_ACCEPT_RESET_REQUEST` (CU-860r8k57h).
 - English and (temporary) Spanish translations of `alertAcceptResetRequest`, `clientMessageForRequestToReset`, `resetNoticeToRequester`, `resetNoticeToOtherResponders`, `resetRequestRejected` (CU-860r8k57h).
-- Allow Duration alerts to repeat. The duration timer is reset after a duration alert is triggered (CU-8678tmmew).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ the code was deployed.
 - `number_of_alerts` integer column to the sessions table (CU-860r8k57h).
 - Chatbot flow to reset a sensor if the `number_of_alerts` in a session meets or exceeds the threshold `SESSION_NUMBER_OF_ALERTS_TO_ACCEPT_RESET_REQUEST` (CU-860r8k57h).
 - English and (temporary) Spanish translations of `alertAcceptResetRequest`, `clientMessageForRequestToReset`, `resetNoticeToRequester`, `resetNoticeToOtherResponders`, `resetRequestRejected` (CU-860r8k57h).
+- Allow Duration alerts to repeat. The duration timer is reset after a duration alert is triggered (CU-8678tmmew).
 
 ### Changed
 

--- a/firmware/boron-ins-fsm/src/stateMachine.cpp
+++ b/firmware/boron-ins-fsm/src/stateMachine.cpp
@@ -244,12 +244,13 @@ void state2_duration() {
         saveStateChangeOrAlert(2, 2);
         stateHandler = state0_idle;
     }
-    else if ((millis() - state2_duration_timer >= state2_max_duration) && !hasDurationAlertBeenSent) {
+    else if (millis() - state2_duration_timer >= state2_max_duration) {
         Log.warn("See duration alert, remaining in state2_duration after alert publish");
         saveStateChangeOrAlert(2, 4);
         Log.error("Duration Alert!!");
         Particle.publish("Duration Alert", "duration alert", PRIVATE);
         hasDurationAlertBeenSent = true;
+        state2_duration_timer = millis();
         stateHandler = state2_duration;
     }
     else {
@@ -300,13 +301,14 @@ void state3_stillness() {
         max_stillness_time = &state3_max_long_stillness_time;  // set to compare against the longer stillness threshold for the rest of this session
         stateHandler = state3_stillness;
     }
-    else if ((millis() - state2_duration_timer >= state2_max_duration) && !hasDurationAlertBeenSent) {
+    else if (millis() - state2_duration_timer >= state2_max_duration) {
         Log.warn("duration alert, remaining in state3 after publish");
         publishStateTransition(3, 3, checkDoor.doorStatus, checkINS.iAverage);
         saveStateChangeOrAlert(3, 4);
         Log.error("Duration Alert!!");
         Particle.publish("Duration Alert", "duration alert", PRIVATE);
         hasDurationAlertBeenSent = true;
+        state2_duration_timer = millis();
         stateHandler = state3_stillness;
     }
     else {


### PR DESCRIPTION
This pull request removes the condition of `!hasDurationAlertBeenSent` when triggering a duration alert. `state2_duration_timer` is also zeroed to the current clock time upon triggering a duration alert.
---
Test Plan:

- [x] set duration timer to 20 seconds and stillness timer to 1 min
- [x] close the door sensor and enter occupancy by shaking the test sensor
- [x] remain still for 1 minute 
- [x] verify that 1 stillness alert and 3 duration alerts have been triggered
- [x] open and close the door sensor, enter occupancy again
- [x] repeat step 3 again, but with movement (staying in state 2)
- [x] verify that 3 duration alerts have been triggered and no stillness alert