### PR TITLE
Upgrade brave-alert-lib to v12.3.0 (CU-13kqjz8).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ the code was deployed.
 
 - Session model (moved to brave-alert-lib) (CU-86791yyvg).
 
+### Changed
+
+- Upgraded brave-alert-lib to v12.3.0 (CU-13kqjz8).
+
 ## [10.6.0] - 2024-01-23
 
 ### Added

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -12,7 +12,7 @@
         "@sentry/node": "^6.2.5",
         "@sentry/tracing": "^6.2.5",
         "axios": "^1.6.0",
-        "brave-alert-lib": "github:bravetechnologycoop/brave-alert-lib#v12.2.0",
+        "brave-alert-lib": "github:bravetechnologycoop/brave-alert-lib#mdb-improve-google-auth",
         "cookie-parser": "^1.4.5",
         "cors": "^2.8.5",
         "execution-time": "^1.4.1",
@@ -1718,7 +1718,7 @@
     },
     "node_modules/brave-alert-lib": {
       "version": "12.2.0",
-      "resolved": "git+ssh://git@github.com/bravetechnologycoop/brave-alert-lib.git#a10cf40101e372220b24ea507b964191cb9af4eb",
+      "resolved": "git+ssh://git@github.com/bravetechnologycoop/brave-alert-lib.git#6944cc3d0ac6e9b47ffc533641f3c23a89de6c1b",
       "dependencies": {
         "@sentry/node": "^6.2.5",
         "@sentry/tracing": "^6.2.5",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -12,7 +12,7 @@
         "@sentry/node": "^6.2.5",
         "@sentry/tracing": "^6.2.5",
         "axios": "^1.6.0",
-        "brave-alert-lib": "github:bravetechnologycoop/brave-alert-lib#mdb-improve-google-auth",
+        "brave-alert-lib": "github:bravetechnologycoop/brave-alert-lib#v12.3.0",
         "cookie-parser": "^1.4.5",
         "cors": "^2.8.5",
         "execution-time": "^1.4.1",
@@ -1717,8 +1717,8 @@
       }
     },
     "node_modules/brave-alert-lib": {
-      "version": "12.2.0",
-      "resolved": "git+ssh://git@github.com/bravetechnologycoop/brave-alert-lib.git#6944cc3d0ac6e9b47ffc533641f3c23a89de6c1b",
+      "version": "12.3.0",
+      "resolved": "git+ssh://git@github.com/bravetechnologycoop/brave-alert-lib.git#e97baae289d8a70da20e3bec68794e05ae328464",
       "dependencies": {
         "@sentry/node": "^6.2.5",
         "@sentry/tracing": "^6.2.5",

--- a/server/package.json
+++ b/server/package.json
@@ -20,7 +20,7 @@
     "@sentry/node": "^6.2.5",
     "@sentry/tracing": "^6.2.5",
     "axios": "^1.6.0",
-    "brave-alert-lib": "github:bravetechnologycoop/brave-alert-lib#mdb-improve-google-auth",
+    "brave-alert-lib": "github:bravetechnologycoop/brave-alert-lib#v12.3.0",
     "cookie-parser": "^1.4.5",
     "cors": "^2.8.5",
     "execution-time": "^1.4.1",

--- a/server/package.json
+++ b/server/package.json
@@ -20,7 +20,7 @@
     "@sentry/node": "^6.2.5",
     "@sentry/tracing": "^6.2.5",
     "axios": "^1.6.0",
-    "brave-alert-lib": "github:bravetechnologycoop/brave-alert-lib#v12.2.0",
+    "brave-alert-lib": "github:bravetechnologycoop/brave-alert-lib#mdb-improve-google-auth",
     "cookie-parser": "^1.4.5",
     "cors": "^2.8.5",
     "execution-time": "^1.4.1",


### PR DESCRIPTION
The updates to brave-alert-lib does not concern BraveSensor just yet; it allows PA to be authorized with the Authorization header, in addition to submission of Google ID Token in the body of a post request.