### PR TITLE
Fix Travis firmware linting step mongodb-org error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,6 +69,7 @@ jobs:
         - wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
         - echo 'deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-12 main' | sudo tee -a /etc/apt/sources.list
         - echo 'deb-src http://apt.llvm.org/xenial/ llvm-toolchain-xenial-12 main' | sudo tee -a /etc/apt/sources.list
+        - sudo apt-get install --force-yes -y mongodb-org
         - sudo apt-get update
       install:
         - sudo apt-get install -y clang-format-12

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,8 +69,7 @@ jobs:
         - wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
         - echo 'deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-12 main' | sudo tee -a /etc/apt/sources.list
         - echo 'deb-src http://apt.llvm.org/xenial/ llvm-toolchain-xenial-12 main' | sudo tee -a /etc/apt/sources.list
-        - sudo apt-get install --force-yes -y mongodb-org
-        - sudo apt-get update
+        - sudo apt-get --allow-unauthenticated update
       install:
         - sudo apt-get install -y clang-format-12
         - sudo apt-get install cppcheck

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,10 +66,10 @@ jobs:
     - stage: 'firmware linting and formatting checks'
       language: python
       before_install:
-        - wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
-        - echo 'deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-12 main' | sudo tee -a /etc/apt/sources.list
-        - echo 'deb-src http://apt.llvm.org/xenial/ llvm-toolchain-xenial-12 main' | sudo tee -a /etc/apt/sources.list
-        - sudo apt-get --allow-unauthenticated update
+        #- wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
+        #- echo 'deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-12 main' | sudo tee -a /etc/apt/sources.list
+        #- echo 'deb-src http://apt.llvm.org/xenial/ llvm-toolchain-xenial-12 main' | sudo tee -a /etc/apt/sources.list
+        - sudo apt-get update
       install:
         - sudo apt-get install -y clang-format-12
         - sudo apt-get install cppcheck

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,7 @@ jobs:
         - wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
         - echo 'deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-12 main' | sudo tee -a /etc/apt/sources.list
         - echo 'deb-src http://apt.llvm.org/xenial/ llvm-toolchain-xenial-12 main' | sudo tee -a /etc/apt/sources.list
-        - echo 'deb [ arch=amd64,arm64 trusted=yes ] http://repo.mongodb.org/apt/ubuntu focal/mongodb-org/4.4 Release' | sudo tee /etc/apt/sources.list.d/mongodb-org-4.4.list
+        - echo 'deb [ arch=amd64,arm64 trusted=yes ] http://repo.mongodb.org/apt/ubuntu focal/mongodb-org/4.4 Release' | sudo tee -a /etc/apt/sources.list
         - sudo apt-get update
       install:
         - sudo apt-get install -y clang-format-12

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,8 +69,7 @@ jobs:
         - wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
         - echo 'deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-12 main' | sudo tee -a /etc/apt/sources.list
         - echo 'deb-src http://apt.llvm.org/xenial/ llvm-toolchain-xenial-12 main' | sudo tee -a /etc/apt/sources.list
-        - sudo ls /etc/apt/sources.list.d/mongodb*
-        - sudo echo "deb [ arch=amd64,arm64 trusted=yes ] http://repo.mongodb.org/apt/ubuntu focal/mongodb-org/4.4 Release" > /etc/apt/sources.list.d/mongodb-org-4.4.list
+        - echo 'deb [ arch=amd64,arm64 trusted=yes ] http://repo.mongodb.org/apt/ubuntu focal/mongodb-org/4.4 Release' | sudo tee /etc/apt/sources.list.d/mongodb-org-4.4.list
         - sudo apt-get update
       install:
         - sudo apt-get install -y clang-format-12

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,6 +63,10 @@ jobs:
         - if [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then npx audit-ci --config ./audit-ci.json; fi
         - npm run lint
         - sudo env "PATH=$PATH" npm test
+    - stage: 'firmware lint'
+      script:
+        - echo 'Please implement this in the future using GitHub Actions.'
+        - echo 'In the mean time, follow the firmware linting instructions before merging your changes.'
     - stage: 'firmware test'
       language: cpp
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,7 @@ jobs:
         - wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
         - echo 'deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-12 main' | sudo tee -a /etc/apt/sources.list
         - echo 'deb-src http://apt.llvm.org/xenial/ llvm-toolchain-xenial-12 main' | sudo tee -a /etc/apt/sources.list
-        - sudo apt-get remove -y mongodb-org
+        - sudo apt autoremove
         - sudo apt-get update
       install:
         - sudo apt-get install -y clang-format-12

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,8 +69,8 @@ jobs:
         - wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
         - echo 'deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-12 main' | sudo tee -a /etc/apt/sources.list
         - echo 'deb-src http://apt.llvm.org/xenial/ llvm-toolchain-xenial-12 main' | sudo tee -a /etc/apt/sources.list
+        - echo 'deb [trusted=yes] http://repo.mongodb.org/apt/ubuntu focal/mongodb-org/4.4 Release' | sudo tee -a /etc/apt/sources.list
         - sudo cat /etc/apt/sources.list
-        - echo 'deb [ arch=amd64,arm64 trusted=yes ] http://repo.mongodb.org/apt/ubuntu focal/mongodb-org/4.4 Release' | sudo tee -a /etc/apt/sources.list
         - sudo apt-get update
       install:
         - sudo apt-get install -y clang-format-12

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,6 +69,7 @@ jobs:
         - wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
         - echo 'deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-12 main' | sudo tee -a /etc/apt/sources.list
         - echo 'deb-src http://apt.llvm.org/xenial/ llvm-toolchain-xenial-12 main' | sudo tee -a /etc/apt/sources.list
+        - sudo cat /etc/apt/sources.list
         - echo 'deb [ arch=amd64,arm64 trusted=yes ] http://repo.mongodb.org/apt/ubuntu focal/mongodb-org/4.4 Release' | sudo tee -a /etc/apt/sources.list
         - sudo apt-get update
       install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,8 +69,6 @@ jobs:
         - wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
         - echo 'deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-12 main' | sudo tee -a /etc/apt/sources.list
         - echo 'deb-src http://apt.llvm.org/xenial/ llvm-toolchain-xenial-12 main' | sudo tee -a /etc/apt/sources.list
-        - echo 'deb [trusted=yes] http://repo.mongodb.org/apt/ubuntu focal/mongodb-org/4.4 Release' | sudo tee -a /etc/apt/sources.list
-        - sudo cat /etc/apt/sources.list
         - sudo apt-get update
       install:
         - sudo apt-get install -y clang-format-12

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ jobs:
         - if [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then npx audit-ci --config ./audit-ci.json; fi
         - npm run lint
         - sudo env "PATH=$PATH" npm test
-    - stage: 'firmware tests'
+    - stage: 'firmware test'
       language: cpp
       script:
         - cd firmware/boron-ins-fsm/test && g++ -std=c++11 -I../inc -I./ -I./mocks -o ConsoleTests consoleFunctionTests.cpp -lstdc++ -lm && ./ConsoleTests -s

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,8 @@ jobs:
         - wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
         - echo 'deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-12 main' | sudo tee -a /etc/apt/sources.list
         - echo 'deb-src http://apt.llvm.org/xenial/ llvm-toolchain-xenial-12 main' | sudo tee -a /etc/apt/sources.list
-        - sudo apt autoremove
+        - sudo ls /etc/apt/sources.list.d/mongodb*
+        - sudo echo "deb [ arch=amd64,arm64 trusted=yes ] http://repo.mongodb.org/apt/ubuntu focal/mongodb-org/4.4 Release" > /etc/apt/sources.list.d/mongodb-org-4.4.list
         - sudo apt-get update
       install:
         - sudo apt-get install -y clang-format-12

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,6 +69,7 @@ jobs:
         - wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
         - echo 'deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-12 main' | sudo tee -a /etc/apt/sources.list
         - echo 'deb-src http://apt.llvm.org/xenial/ llvm-toolchain-xenial-12 main' | sudo tee -a /etc/apt/sources.list
+        - sudo apt-get remove -y mongodb-org
         - sudo apt-get update
       install:
         - sudo apt-get install -y clang-format-12

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,19 +63,6 @@ jobs:
         - if [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then npx audit-ci --config ./audit-ci.json; fi
         - npm run lint
         - sudo env "PATH=$PATH" npm test
-    - stage: 'firmware linting and formatting checks'
-      language: python
-      before_install:
-        #- wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
-        #- echo 'deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-12 main' | sudo tee -a /etc/apt/sources.list
-        #- echo 'deb-src http://apt.llvm.org/xenial/ llvm-toolchain-xenial-12 main' | sudo tee -a /etc/apt/sources.list
-        - sudo apt-get update
-      install:
-        - sudo apt-get install -y clang-format-12
-        - sudo apt-get install cppcheck
-      script:
-        - cd firmware/boron-ins-fsm && python clang-format-check.py
-        - cppcheck src --enable=warning,style,performance,portability --error-exitcode=1
     - stage: 'firmware tests'
       language: cpp
       script:


### PR DESCRIPTION
Travis environment is depending on the mongodb-org which has an expired signing key. Luckily this error is only in the firmware linting step. As we're hoping to migrate to GitHub Actions for testing in the future, I'd rather replace this step with a suggestion that devs run linting scripts themselves in good faith, rather than wait for Travis to resolve this 😓 .