### PR TITLE
Minimized getLocations call (CU-86dqq93dp)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ the code was deployed.
 
 ## [Unreleased]
 
+### Changed
+
+- Changed `logSensorsVital` and `getMostRecentSessionWithDeviceid` to use `location` instead of `locationid` (CU-86dqq93dp).
+- Changed `getMostRecentSessionWithDeviceid`to `getMostRecentSessionWithDevice` to reflect the change of the function (CU-86dqq93dp).
+- Changed `sensorsVitalDBFactory` to use location instead of locationid in the logSensorsVital call (CU-86dqq93dp).
+- Modified several test cases in `handleHeartbeatTest.js` to reflect the changes of `logSensorsVital`, `getMostRecentSessionWithDevice`, and `sensorsVitalDBFactory` (CU-86dqq93dp).
+
 ## [10.10.0] - 2024-06-04
 
 ### Added

--- a/server/dashboard.js
+++ b/server/dashboard.js
@@ -212,7 +212,7 @@ async function renderDashboardPage(req, res) {
     const allDisplayedLocations = (await db.getLocations()).filter(location => location.isDisplayed)
 
     for (const location of allDisplayedLocations) {
-      const recentSession = await db.getMostRecentSessionWithDeviceId(location.id)
+      const recentSession = await db.getMostRecentSessionWithDevice(location)
       if (recentSession !== null) {
         const sessionCreatedAt = Date.parse(recentSession.createdAt)
         const timeSinceLastSession = await helpers.generateCalculatedTimeDifferenceString(sessionCreatedAt, db)
@@ -362,7 +362,7 @@ async function renderClientDetailsPage(req, res) {
     const locations = await db.getLocationsFromClientId(currentClient.id)
 
     for (const location of locations) {
-      const recentSession = await db.getMostRecentSessionWithDeviceId(location.id)
+      const recentSession = await db.getMostRecentSessionWithDevice(location)
       if (recentSession !== null) {
         const sessionCreatedAt = Date.parse(recentSession.createdAt)
         const timeSinceLastSession = await helpers.generateCalculatedTimeDifferenceString(sessionCreatedAt, db)

--- a/server/db/db.js
+++ b/server/db/db.js
@@ -397,10 +397,10 @@ async function getCurrentTimeForHealthCheck() {
 }
 
 // Gets the most recent session data in the table for a specified location
-async function getMostRecentSessionWithDeviceId(deviceId, pgClient) {
+async function getMostRecentSessionWithDevice(device, pgClient) {
   try {
     const results = await helpers.runQuery(
-      'getMostRecentSessionWithDeviceId',
+      'getMostRecentSessionWithDevice',
       `
       SELECT *
       FROM sessions
@@ -408,7 +408,7 @@ async function getMostRecentSessionWithDeviceId(deviceId, pgClient) {
       ORDER BY created_at DESC
       LIMIT 1
       `,
-      [deviceId],
+      [device.id],
       pool,
       pgClient,
     )
@@ -417,10 +417,9 @@ async function getMostRecentSessionWithDeviceId(deviceId, pgClient) {
       return null
     }
 
-    const allDevices = await getDevices(pgClient)
-    return createSessionFromRow(results.rows[0], allDevices)
+    return createSessionFromRow(results.rows[0], [device])
   } catch (err) {
-    helpers.logError(`Error running the getMostRecentSessionWithDeviceId query: ${err.toString()}`)
+    helpers.logError(`Error running the getMostRecentSessionWithDevice query: ${err.toString()}`)
   }
 }
 
@@ -1628,7 +1627,7 @@ module.exports = {
   getLocations,
   getLocationsFromClientId,
   getMostRecentSensorsVitalWithLocation,
-  getMostRecentSessionWithDeviceId,
+  getMostRecentSessionWithDevice,
   getMostRecentSessionWithPhoneNumbers,
   getRecentSensorsVitals,
   getRecentSensorsVitalsWithClientId,

--- a/server/db/db.js
+++ b/server/db/db.js
@@ -12,7 +12,7 @@ const pool = new pg.Pool({
   user: helpers.getEnvVar('PG_USER'),
   database: helpers.getEnvVar('PG_DATABASE'),
   password: helpers.getEnvVar('PG_PASSWORD'),
-  ssl: false, // { rejectUnauthorized: false },
+  ssl: { rejectUnauthorized: false },
 })
 
 // 1114 is OID for timestamp in Postgres

--- a/server/db/db.js
+++ b/server/db/db.js
@@ -1292,16 +1292,7 @@ async function getMostRecentSensorsVitalWithLocation(location, pgClient) {
   }
 }
 
-async function logSensorsVital(
-  location,
-  missedDoorMessages,
-  isDoorBatteryLow,
-  doorLastSeenAt,
-  resetReason,
-  stateTransitions,
-  isTampered,
-  pgClient,
-) {
+async function logSensorsVital(location, missedDoorMessages, isDoorBatteryLow, doorLastSeenAt, resetReason, stateTransitions, isTampered, pgClient) {
   try {
     const results = await helpers.runQuery(
       'logSensorsVital',

--- a/server/test/integration/vitalsTest/handleHeartbeatTest.js
+++ b/server/test/integration/vitalsTest/handleHeartbeatTest.js
@@ -228,7 +228,6 @@ describe('vitals.js integration tests: handleHeartbeat', () => {
     })
   })
 
-  // FIXME: changes here
   describe('POST request heartbeat events with mock INS Firmware State Machine when battery level is normal', () => {
     beforeEach(async () => {
       await db.clearTables()
@@ -303,7 +302,6 @@ describe('vitals.js integration tests: handleHeartbeat', () => {
     })
   })
 
-  // FIXME: changes here
   describe('POST request heartbeat events with mock INS Firmware State machine when it has not seen a door message since the last restart and there have been no previous heartbeats', () => {
     beforeEach(async () => {
       await db.clearTables()
@@ -363,13 +361,12 @@ describe('vitals.js integration tests: handleHeartbeat', () => {
     it('should call logSensorsVital with the same doorLastSeen, isTampered, and isDoorBatteryLow values as the most recent heartbeat from the DB', async () => {
       const doorLastSeenAt = new Date('2022-06-06T15:03:15')
       await sensorsVitalDBFactory(db, {
-        locationid: testLocation1Id,
+        location: this.testLocation,
         doorLastSeenAt,
         isTampered: true,
         isDoorBatteryLow: false,
       })
       
-      // TODO: error here
       await unknownDoorLastMessageHeartbeat(radar_coreID)
       expect(db.logSensorsVital).to.be.calledWithExactly(this.testLocation, 0, false, doorLastSeenAt, 'NONE', [], true)
     })
@@ -377,13 +374,12 @@ describe('vitals.js integration tests: handleHeartbeat', () => {
     it('should call logSensorsVital with the same doorLastSeen, isTampered, and isDoorBatteryLow values as the most recent heartbeat from the DB with different values', async () => {
       const doorLastSeenAt = new Date('2023-01-01T15:03:15')
       await sensorsVitalDBFactory(db, {
-        locationid: testLocation1Id,
+        location: this.testLocation,
         doorLastSeenAt,
         isTampered: false,
         isDoorBatteryLow: true,
       })
 
-      // TODO: error here
       await unknownDoorLastMessageHeartbeat(radar_coreID)
       expect(db.logSensorsVital).to.be.calledWithExactly(this.testLocation, 0, true, doorLastSeenAt, 'NONE', [], false)
     })

--- a/server/test/integration/vitalsTest/handleHeartbeatTest.js
+++ b/server/test/integration/vitalsTest/handleHeartbeatTest.js
@@ -366,7 +366,7 @@ describe('vitals.js integration tests: handleHeartbeat', () => {
         isTampered: true,
         isDoorBatteryLow: false,
       })
-      
+
       await unknownDoorLastMessageHeartbeat(radar_coreID)
       expect(db.logSensorsVital).to.be.calledWithExactly(this.testLocation, 0, false, doorLastSeenAt, 'NONE', [], true)
     })

--- a/server/test/integration/vitalsTest/handleHeartbeatTest.js
+++ b/server/test/integration/vitalsTest/handleHeartbeatTest.js
@@ -228,12 +228,13 @@ describe('vitals.js integration tests: handleHeartbeat', () => {
     })
   })
 
+  // FIXME: changes here
   describe('POST request heartbeat events with mock INS Firmware State Machine when battery level is normal', () => {
     beforeEach(async () => {
       await db.clearTables()
 
       const client = await factories.clientDBFactory(db)
-      await factories.locationDBFactory(db, {
+      this.testLocation = await factories.locationDBFactory(db, {
         locationid: testLocation1Id,
         serialNumber: radar_coreID,
         clientId: client.id,
@@ -281,7 +282,7 @@ describe('vitals.js integration tests: handleHeartbeat', () => {
       await normalHeartbeat(radar_coreID)
 
       // 1000 ms before the current DB time
-      expect(db.logSensorsVital).to.be.calledOnceWithExactly(testLocation1Id, 0, false, new Date('2000-01-01T11:11:10Z'), 'NONE', [], false)
+      expect(db.logSensorsVital).to.be.calledOnceWithExactly(this.testLocation, 0, false, new Date('2000-01-01T11:11:10Z'), 'NONE', [], false)
     })
 
     it('should not call logSentry', async () => {
@@ -302,12 +303,13 @@ describe('vitals.js integration tests: handleHeartbeat', () => {
     })
   })
 
+  // FIXME: changes here
   describe('POST request heartbeat events with mock INS Firmware State machine when it has not seen a door message since the last restart and there have been no previous heartbeats', () => {
     beforeEach(async () => {
       await db.clearTables()
 
       const client = await factories.clientDBFactory(db)
-      await factories.locationDBFactory(db, {
+      this.testLocation = await factories.locationDBFactory(db, {
         locationid: testLocation1Id,
         serialNumber: radar_coreID,
         clientId: client.id,
@@ -329,7 +331,7 @@ describe('vitals.js integration tests: handleHeartbeat', () => {
 
     it('should call logSensorsVital with the current time from the DB and false for isTampered and isDoorBatteryLow', async () => {
       await unknownDoorLastMessageHeartbeat(radar_coreID)
-      expect(db.logSensorsVital).to.be.calledWithExactly(testLocation1Id, 0, false, this.currentTime, 'NONE', [], false)
+      expect(db.logSensorsVital).to.be.calledWithExactly(this.testLocation, 0, false, this.currentTime, 'NONE', [], false)
     })
   })
 
@@ -338,7 +340,7 @@ describe('vitals.js integration tests: handleHeartbeat', () => {
       await db.clearTables()
 
       const client = await factories.clientDBFactory(db)
-      await factories.locationDBFactory(db, {
+      this.testLocation = await factories.locationDBFactory(db, {
         locationid: testLocation1Id,
         serialNumber: radar_coreID,
         clientId: client.id,
@@ -366,9 +368,10 @@ describe('vitals.js integration tests: handleHeartbeat', () => {
         isTampered: true,
         isDoorBatteryLow: false,
       })
-
+      
+      // TODO: error here
       await unknownDoorLastMessageHeartbeat(radar_coreID)
-      expect(db.logSensorsVital).to.be.calledWithExactly(testLocation1Id, 0, false, doorLastSeenAt, 'NONE', [], true)
+      expect(db.logSensorsVital).to.be.calledWithExactly(this.testLocation, 0, false, doorLastSeenAt, 'NONE', [], true)
     })
 
     it('should call logSensorsVital with the same doorLastSeen, isTampered, and isDoorBatteryLow values as the most recent heartbeat from the DB with different values', async () => {
@@ -380,8 +383,9 @@ describe('vitals.js integration tests: handleHeartbeat', () => {
         isDoorBatteryLow: true,
       })
 
+      // TODO: error here
       await unknownDoorLastMessageHeartbeat(radar_coreID)
-      expect(db.logSensorsVital).to.be.calledWithExactly(testLocation1Id, 0, true, doorLastSeenAt, 'NONE', [], false)
+      expect(db.logSensorsVital).to.be.calledWithExactly(this.testLocation, 0, true, doorLastSeenAt, 'NONE', [], false)
     })
   })
 

--- a/server/testingHelpers.js
+++ b/server/testingHelpers.js
@@ -43,18 +43,12 @@ function sensorsVitalFactory(overrides = {}) {
 
 async function sensorsVitalDBFactory(db, overrides = {}) {
   // prettier-ignore
-  // FIXME: added location as logSensorsVital now uses location
-
-  // const locations = {
-  //   locationid: overrides.locationid || 'myLocation',
-  // }
-
-  const location = factories.locationFactory({
-    locationid: 'myLocation'
-  })
+  const location = {
+    locationid: overrides.locationid || 'myLocation',
+  }
 
   const sensorVital = await db.logSensorsVital(
-    location,
+    overrides.location !== undefined ? overrides.location: location,
     overrides.missedDoorMessages !== undefined ? overrides.missedDoorMessages : 0,
     overrides.isDoorBatteryLow !== undefined ? overrides.isDoorBatteryLow : false,
     overrides.doorLastSeenAt !== undefined ? overrides.doorLastSeenAt : new Date('2022-01-03T04:05:06'),

--- a/server/testingHelpers.js
+++ b/server/testingHelpers.js
@@ -4,7 +4,6 @@ const { fill } = require('lodash')
 // In-house dependencies
 const { factories, helpers } = require('brave-alert-lib')
 const SensorsVital = require('./SensorsVital')
-const { locationFactory } = require('brave-alert-lib/lib/models/factories')
 
 function getRandomInt(minValue, maxValue) {
   const min = Math.ceil(minValue)
@@ -48,7 +47,7 @@ async function sensorsVitalDBFactory(db, overrides = {}) {
   }
 
   const sensorVital = await db.logSensorsVital(
-    overrides.location !== undefined ? overrides.location: location,
+    overrides.location !== undefined ? overrides.location : location,
     overrides.missedDoorMessages !== undefined ? overrides.missedDoorMessages : 0,
     overrides.isDoorBatteryLow !== undefined ? overrides.isDoorBatteryLow : false,
     overrides.doorLastSeenAt !== undefined ? overrides.doorLastSeenAt : new Date('2022-01-03T04:05:06'),

--- a/server/testingHelpers.js
+++ b/server/testingHelpers.js
@@ -4,6 +4,7 @@ const { fill } = require('lodash')
 // In-house dependencies
 const { factories, helpers } = require('brave-alert-lib')
 const SensorsVital = require('./SensorsVital')
+const { locationFactory } = require('brave-alert-lib/lib/models/factories')
 
 function getRandomInt(minValue, maxValue) {
   const min = Math.ceil(minValue)
@@ -44,9 +45,13 @@ async function sensorsVitalDBFactory(db, overrides = {}) {
   // prettier-ignore
   // FIXME: added location as logSensorsVital now uses location
 
-  const location = {
-    locationid: overrides.locationid || 'myLocation',
-  }
+  // const locations = {
+  //   locationid: overrides.locationid || 'myLocation',
+  // }
+
+  const location = factories.locationFactory({
+    locationid: 'myLocation'
+  })
 
   const sensorVital = await db.logSensorsVital(
     location,

--- a/server/vitals.js
+++ b/server/vitals.js
@@ -316,7 +316,7 @@ async function handleHeartbeat(req, res) {
           }
 
           await db.logSensorsVital(
-            location.locationid,
+            location,
             doorMissedMessagesCount,
             doorLowBatteryFlag,
             doorLastSeenAt,


### PR DESCRIPTION
Changed logSensorsVitals and getMostRecentSessionWithDeviceid to use location instead of it's id so it does not need to call getLocations. Also changed the test cases to reflect that.

Test Plan

- [x] Passes all test cases (new and old)
- [x] Runs in development