### PR TITLE
Only display clients on the dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ the code was deployed.
 
 ## [Unreleased]
 
+- Removed clients from dashboard
+
 ## [10.12.0] - 2024-08-20
 
 ### Added

--- a/server/dashboard.js
+++ b/server/dashboard.js
@@ -215,16 +215,14 @@ async function renderDashboardPage(req, res) {
       const recentSession = await db.getMostRecentSessionWithDevice(location)
       if (recentSession !== null) {
         const sessionCreatedAt = Date.parse(recentSession.createdAt)
-        //const timeSinceLastSession = await helpers.generateCalculatedTimeDifferenceString(sessionCreatedAt, db)
-        //location.sessionStart = timeSinceLastSession
         try
         {
           location.sessionStart = new Date(sessionCreatedAt).toString()
           
         }
-        catch(err)
+        catch (err) 
         {
-          location.sessionStart = "INVALID DATE";
+          location.sessionStart = 'INVALID DATE';
         }
       }
     }

--- a/server/dashboard.js
+++ b/server/dashboard.js
@@ -215,14 +215,10 @@ async function renderDashboardPage(req, res) {
       const recentSession = await db.getMostRecentSessionWithDevice(location)
       if (recentSession !== null) {
         const sessionCreatedAt = Date.parse(recentSession.createdAt)
-        try
-        {
+        try {
           location.sessionStart = new Date(sessionCreatedAt).toString()
-          
-        }
-        catch (err) 
-        {
-          location.sessionStart = 'INVALID DATE';
+        } catch (err) {
+          location.sessionStart = 'INVALID DATE'
         }
       }
     }

--- a/server/dashboard.js
+++ b/server/dashboard.js
@@ -209,21 +209,6 @@ async function downloadCsv(req, res) {
 async function renderDashboardPage(req, res) {
   try {
     const displayedClients = (await db.getClients()).filter(client => client.isDisplayed)
-    const allDisplayedLocations = (await db.getLocations()).filter(location => location.isDisplayed)
-
-    for (const client of displayedClients) {
-      client.locations = allDisplayedLocations
-        .filter(location => location.client.id === client.id)
-        .map(location => {
-          return {
-            name: location.displayName,
-            id: location.id,
-            sessionStart: location.sessionStart,
-            isSendingAlerts: location.isSendingAlerts && location.client.isSendingAlerts,
-            isSendingVitals: location.isSendingVitals && location.client.isSendingVitals,
-          }
-        })
-    }
 
     const viewParams = {
       clients: displayedClients,

--- a/server/dashboard.js
+++ b/server/dashboard.js
@@ -211,18 +211,6 @@ async function renderDashboardPage(req, res) {
     const displayedClients = (await db.getClients()).filter(client => client.isDisplayed)
     const allDisplayedLocations = (await db.getLocations()).filter(location => location.isDisplayed)
 
-    for (const location of allDisplayedLocations) {
-      const recentSession = await db.getMostRecentSessionWithDevice(location)
-      if (recentSession !== null) {
-        const sessionCreatedAt = Date.parse(recentSession.createdAt)
-        try {
-          location.sessionStart = new Date(sessionCreatedAt).toString()
-        } catch (err) {
-          location.sessionStart = 'INVALID DATE'
-        }
-      }
-    }
-
     for (const client of displayedClients) {
       client.locations = allDisplayedLocations
         .filter(location => location.client.id === client.id)

--- a/server/dashboard.js
+++ b/server/dashboard.js
@@ -215,8 +215,17 @@ async function renderDashboardPage(req, res) {
       const recentSession = await db.getMostRecentSessionWithDevice(location)
       if (recentSession !== null) {
         const sessionCreatedAt = Date.parse(recentSession.createdAt)
-        const timeSinceLastSession = await helpers.generateCalculatedTimeDifferenceString(sessionCreatedAt, db)
-        location.sessionStart = timeSinceLastSession
+        //const timeSinceLastSession = await helpers.generateCalculatedTimeDifferenceString(sessionCreatedAt, db)
+        //location.sessionStart = timeSinceLastSession
+        try
+        {
+          location.sessionStart = new Date(sessionCreatedAt).toString()
+          
+        }
+        catch(err)
+        {
+          location.sessionStart = "INVALID DATE";
+        }
       }
     }
 

--- a/server/mustache-templates/landingPage.mst
+++ b/server/mustache-templates/landingPage.mst
@@ -42,13 +42,6 @@
         </div>
     </div>
     
-    <script>
-        function reloadPage() {
-            location.reload(true)
-        }
-        setInterval(reloadPage, 30000)
-    </script>
-    
     <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>

--- a/server/mustache-templates/landingPage.mst
+++ b/server/mustache-templates/landingPage.mst
@@ -24,8 +24,6 @@
                     <thead>
                         <tr class="table-header" scope="row">
                             <th scope="col">Client</th>
-                            <th scope="col"><h5>Location</h5></th>
-                            <th scope="col"><h5>Last Session Started</h5></th>
                             <th scope="col">Sends Alerts?</th>
                             <th scope="col">Sends Vitals?</th>
                         </tr>
@@ -34,20 +32,9 @@
                     {{#clients}}
                         <tr class="table-data table-secondary">
                             <th scope="row"><a href="/clients/{{id}}">{{displayName}}</a></th>
-                            <td></td>
-                            <td></td>
                             <td>{{#isSendingAlerts}}y{{/isSendingAlerts}}{{^isSendingAlerts}}NOPE{{/isSendingAlerts}}</td>
                             <td>{{#isSendingVitals}}y{{/isSendingVitals}}{{^isSendingVitals}}NOPE{{/isSendingVitals}}</td>
                         </tr>
-                        {{#locations}}
-                            <tr class="table-data">
-                                <td></td>
-                                <th scope="row"><a href="/locations/{{id}}">{{name}}</a></th>
-                                <td>{{sessionStart}}</td>
-                                <td>{{#isSendingAlerts}}y{{/isSendingAlerts}}{{^isSendingAlerts}}NOPE{{/isSendingAlerts}}</td>
-                                <td>{{#isSendingVitals}}y{{/isSendingVitals}}{{^isSendingVitals}}NOPE{{/isSendingVitals}}</td>
-                            </tr>
-                        {{/locations}}
                     {{/clients}}
                     </tbody>
                 </table>


### PR DESCRIPTION
Previously, the dashboard would display all sensors, we suspect that this may be what is causing the load times to be so long.

Removed the sensors on the dashboard, they will still be viewable through the client page.