### PR TITLE
New door sensor prefix for recent batch order (CU-86duk2kpg)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,10 @@ the code was deployed.
 
 ## [Unreleased]
 
-<<<<<<< jl-new-door-sensor-BLE-id
 - Removed clients from dashboard (CU-86dubpmbt).
 - Added new prefix for BLE door sensor ID's (CU-86duk2kpg).
-=======
 - Add city, project to clients_extension through migration script (CU-86du6jp33)
 - Removed clients from dashboard
->>>>>>> main
 
 ## [10.12.0] - 2024-08-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ the code was deployed.
 
 ## [Unreleased]
 
-- Removed clients from dashboard
+- Removed clients from dashboard (CU-86dubpmbt).
+- Added new prefix for BLE door sensor ID's (CU-86duk2kpg).
 
 ## [10.12.0] - 2024-08-20
 

--- a/firmware/boron-ins-fsm/src/imDoorSensor.cpp
+++ b/firmware/boron-ins-fsm/src/imDoorSensor.cpp
@@ -181,6 +181,8 @@ void threadBLEScanner(void *param) {
         // add device ID for IM24 to the filter
         sprintf(address, "AC:9A:22:%02X:%02X:%02X", globalDoorID.byte3, globalDoorID.byte2, globalDoorID.byte1);
         filter.address(address);
+        sprintf(address, "80:FB:F1:%02X:%02X:%02X", globalDoorID.byte3, globalDoorID.byte2, globalDoorID.byte1);
+        filter.address(address);
 
         // scanning for IM21 and IM24 door sensors of correct device ID
         spark::Vector<BleScanResult> scanResults = BLE.scanWithFilter(filter);


### PR DESCRIPTION
This PR adds a BLE id prefix for the latest batch of IM21 door sensors. This is required for the new batch of door sensors to be able to pair with the main sensor unit.

___
Test Plan:
- [ ] Enter the 6 digits of the door sensor ID from the new batch of door sensors into the `Change_IM21_Door_ID` console function
- [ ] Turn on debugging publishes, open the door sensor, ensure that the door_status reads 0x02
- [ ] close the door sensor, ensure that the door_status reads 0x00
- [ ] leave the door sensor untouched for 10 min, ensure that the door_status reads 0x08
- [ ] open the door sensor and leave untouched for another 10 min, ensure that the door_status reads 0x0A