### PR TITLE
Make fallback number optional for Sensors dashboard (CU-86du49q25)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ the code was deployed.
 ## [Unreleased]
 
 - Update pw migration instructions (CU-86duhae9t)
+- Make fallback number optional for Sensors dashboard (CU-86du49q25).
 
 ### Changed
 

--- a/server/dashboard.js
+++ b/server/dashboard.js
@@ -370,9 +370,7 @@ async function renderClientDetailsPage(req, res) {
 }
 
 const validateNewClient = [
-  Validator.body(['displayName', 'responderPhoneNumbers', 'fromPhoneNumber', 'language', 'incidentCategories'])
-    .trim()
-    .notEmpty(),
+  Validator.body(['displayName', 'responderPhoneNumbers', 'fromPhoneNumber', 'language', 'incidentCategories']).trim().notEmpty(),
   Validator.body(['fallbackPhoneNumbers']).trim(),
   Validator.body(['reminderTimeout', 'fallbackTimeout']).trim().isInt({ min: 0 }),
 ]
@@ -408,9 +406,7 @@ async function submitNewClient(req, res) {
           ? data.heartbeatPhoneNumbers.split(',').map(phone => phone.trim())
           : []
       const fallbackPhoneNumbers =
-        data.fallbackPhoneNumbers && data.fallbackPhoneNumbers.trim() !== ''
-          ? data.fallbackPhoneNumbers.split(',').map(phone => phone.trim())
-          : [];
+        data.fallbackPhoneNumbers && data.fallbackPhoneNumbers.trim() !== '' ? data.fallbackPhoneNumbers.split(',').map(phone => phone.trim()) : []
 
       const newClient = await db.createClient(
         data.displayName,
@@ -446,7 +442,6 @@ const validateEditClient = [
   Validator.body([
     'displayName',
     'responderPhoneNumbers',
-    'fallbackPhoneNumbers',
     'fromPhoneNumber',
     'incidentCategories',
     'isDisplayed',
@@ -456,6 +451,7 @@ const validateEditClient = [
   ])
     .trim()
     .notEmpty(),
+  Validator.body(['fallbackPhoneNumbers']).trim(),
   Validator.body(['reminderTimeout', 'fallbackTimeout']).trim().isInt({ min: 0 }),
 ]
 
@@ -489,13 +485,15 @@ async function submitEditClient(req, res) {
         data.heartbeatPhoneNumbers !== undefined && data.heartbeatPhoneNumbers.trim() !== ''
           ? data.heartbeatPhoneNumbers.split(',').map(phone => phone.trim())
           : []
+      const fallbackPhoneNumbers =
+        data.fallbackPhoneNumbers && data.fallbackPhoneNumbers.trim() !== '' ? data.fallbackPhoneNumbers.split(',').map(phone => phone.trim()) : []
 
       await db.updateClient(
         data.displayName,
         data.fromPhoneNumber,
         newResponderPhoneNumbers,
         data.reminderTimeout,
-        data.fallbackPhoneNumbers.split(',').map(phone => phone.trim()),
+        fallbackPhoneNumbers,
         data.fallbackTimeout,
         newHeartbeatPhoneNumbers,
         data.incidentCategories.split(',').map(category => category.trim()),

--- a/server/dashboard.js
+++ b/server/dashboard.js
@@ -370,9 +370,10 @@ async function renderClientDetailsPage(req, res) {
 }
 
 const validateNewClient = [
-  Validator.body(['displayName', 'responderPhoneNumbers', 'fallbackPhoneNumbers', 'fromPhoneNumber', 'language', 'incidentCategories'])
+  Validator.body(['displayName', 'responderPhoneNumbers', 'fromPhoneNumber', 'language', 'incidentCategories'])
     .trim()
     .notEmpty(),
+  Validator.body(['fallbackPhoneNumbers']).trim(),
   Validator.body(['reminderTimeout', 'fallbackTimeout']).trim().isInt({ min: 0 }),
 ]
 
@@ -406,12 +407,16 @@ async function submitNewClient(req, res) {
         data.heartbeatPhoneNumbers !== undefined && data.heartbeatPhoneNumbers.trim() !== ''
           ? data.heartbeatPhoneNumbers.split(',').map(phone => phone.trim())
           : []
+      const fallbackPhoneNumbers =
+        data.fallbackPhoneNumbers && data.fallbackPhoneNumbers.trim() !== ''
+          ? data.fallbackPhoneNumbers.split(',').map(phone => phone.trim())
+          : [];
 
       const newClient = await db.createClient(
         data.displayName,
         newResponderPhoneNumbers,
         data.reminderTimeout,
-        data.fallbackPhoneNumbers.split(',').map(phone => phone.trim()),
+        fallbackPhoneNumbers,
         data.fromPhoneNumber,
         data.fallbackTimeout,
         newHeartbeatPhoneNumbers,

--- a/server/db/db.js
+++ b/server/db/db.js
@@ -12,8 +12,7 @@ const pool = new pg.Pool({
   user: helpers.getEnvVar('PG_USER'),
   database: helpers.getEnvVar('PG_DATABASE'),
   password: helpers.getEnvVar('PG_PASSWORD'),
-  ssl: false,
-  // ssl: { rejectUnauthorized: false },
+  ssl: { rejectUnauthorized: false },
 })
 
 // 1114 is OID for timestamp in Postgres

--- a/server/db/db.js
+++ b/server/db/db.js
@@ -12,7 +12,8 @@ const pool = new pg.Pool({
   user: helpers.getEnvVar('PG_USER'),
   database: helpers.getEnvVar('PG_DATABASE'),
   password: helpers.getEnvVar('PG_PASSWORD'),
-  ssl: { rejectUnauthorized: false },
+  ssl: false,
+  // ssl: { rejectUnauthorized: false },
 })
 
 // 1114 is OID for timestamp in Postgres

--- a/server/mustache-templates/newClient.mst
+++ b/server/mustache-templates/newClient.mst
@@ -37,7 +37,7 @@
                 <div class="form-group row justify-content-start row-no-gutters">
                     <label for="fallbackPhoneNumbers" class="col-sm-3 col-form-label">Fallback Phone Numbers:</label>
                     <div class="col-sm-5">
-                        <input type="text" class="form-control" name="fallbackPhoneNumbers" value="{{fallbackPhoneNumbers}}" required pattern="[+][1]\d{10}([,][+][1]\d{10})*">
+                        <input type="text" class="form-control" name="fallbackPhoneNumbers" value="{{fallbackPhoneNumbers}}" pattern="[+][1]\d{10}([,][+][1]\d{10})*">
                         <small id="fallbackPhoneNumbersHelp" class="form-text text-muted">Each phone number has +1 in front and separated by commas with no dashes or spaces, please (eg. +14445556789,+12223334444,+11231231234)</small>
                     </div>
                 </div>

--- a/server/test/integration/dashboardTest/submitEditClientTest.js
+++ b/server/test/integration/dashboardTest/submitEditClientTest.js
@@ -353,6 +353,78 @@ describe('dashboard.js integration tests: submitEditClient', () => {
     })
   })
 
+  describe('for a request that contains valid non-empty fields but with no fallbackPhoneNumbers', () => {
+    beforeEach(async () => {
+      await this.agent.post('/login').send({
+        username: helpers.getEnvVar('WEB_USERNAME'),
+        password: helpers.getEnvVar('PASSWORD'),
+      })
+
+      this.newDisplayname = 'New Display Name'
+      this.newFromPhoneNumber = '+17549553216'
+      this.newResponderPhoneNumbers = ['+18885554444']
+      this.heartbeatPhoneNumbers = ['+1', '+2', '+3']
+      this.incidentCategories = ['Cat1', 'Cat2']
+      this.reminderTimeout = 5
+      this.fallbackTimeout = 10
+      this.isDisplayed = true
+      this.isSendingAlerts = true
+      this.isSendingVitals = true
+      this.language = 'en'
+      this.goodRequest = {
+        displayName: this.newDisplayname,
+        fromPhoneNumber: this.newFromPhoneNumber,
+        responderPhoneNumbers: this.newResponderPhoneNumbers.join(','),
+        heartbeatPhoneNumbers: this.heartbeatPhoneNumbers.join(','),
+        incidentCategories: this.incidentCategories.join(','),
+        reminderTimeout: this.reminderTimeout,
+        fallbackTimeout: this.fallbackTimeout,
+        isDisplayed: this.isDisplayed,
+        isSendingAlerts: this.isSendingAlerts,
+        isSendingVitals: this.isSendingVitals,
+        language: this.language,
+      }
+
+      this.response = await this.agent.post(`/clients/${this.existingClient.id}`).send(this.goodRequest)
+    })
+
+    it('should return 200', () => {
+      expect(this.response).to.have.status(200)
+    })
+
+    it('should update the client in the database', async () => {
+      const updatedClient = await db.getClientWithClientId(this.existingClient.id)
+
+      expect({
+        displayName: updatedClient.displayName,
+        fromPhoneNumber: updatedClient.fromPhoneNumber,
+        responderPhoneNumbers: updatedClient.responderPhoneNumbers,
+        fallbackPhoneNumbers: updatedClient.fallbackPhoneNumbers,
+        heartbeatPhoneNumbers: updatedClient.heartbeatPhoneNumbers,
+        incidentCategories: updatedClient.incidentCategories,
+        reminderTimeout: updatedClient.reminderTimeout,
+        fallbackTimeout: updatedClient.fallbackTimeout,
+        isDisplayed: updatedClient.isDisplayed,
+        isSendingAlerts: updatedClient.isSendingAlerts,
+        isSendingVitals: updatedClient.isSendingVitals,
+        language: updatedClient.language,
+      }).to.eql({
+        displayName: this.newDisplayname,
+        fromPhoneNumber: this.newFromPhoneNumber,
+        responderPhoneNumbers: this.newResponderPhoneNumbers,
+        fallbackPhoneNumbers: [],
+        heartbeatPhoneNumbers: this.heartbeatPhoneNumbers,
+        incidentCategories: this.incidentCategories,
+        reminderTimeout: this.reminderTimeout,
+        fallbackTimeout: this.fallbackTimeout,
+        isDisplayed: this.isDisplayed,
+        isSendingAlerts: this.isSendingAlerts,
+        isSendingVitals: this.isSendingVitals,
+        language: this.language,
+      })
+    })
+  })
+
   describe('for a request that contains valid non-empty fields but with no responderPhoneNumbers', () => {
     beforeEach(async () => {
       await this.agent.post('/login').send({
@@ -440,7 +512,7 @@ describe('dashboard.js integration tests: submitEditClient', () => {
 
     it('should log the error', () => {
       expect(helpers.log).to.have.been.calledWith(
-        `Bad request to /clients/${this.existingClient.id}: displayName (Invalid value),responderPhoneNumbers (Invalid value),fallbackPhoneNumbers (Invalid value),fromPhoneNumber (Invalid value),incidentCategories (Invalid value),isDisplayed (Invalid value),isSendingAlerts (Invalid value),isSendingVitals (Invalid value),language (Invalid value),reminderTimeout (Invalid value),fallbackTimeout (Invalid value)`,
+        `Bad request to /clients/${this.existingClient.id}: displayName (Invalid value),responderPhoneNumbers (Invalid value),fromPhoneNumber (Invalid value),incidentCategories (Invalid value),isDisplayed (Invalid value),isSendingAlerts (Invalid value),isSendingVitals (Invalid value),language (Invalid value),reminderTimeout (Invalid value),fallbackTimeout (Invalid value)`,
       )
     })
   })
@@ -467,7 +539,7 @@ describe('dashboard.js integration tests: submitEditClient', () => {
 
     it('should log the error', () => {
       expect(helpers.log).to.have.been.calledWith(
-        `Bad request to /clients/${this.existingClient.id}: displayName (Invalid value),responderPhoneNumbers (Invalid value),fallbackPhoneNumbers (Invalid value),fromPhoneNumber (Invalid value),incidentCategories (Invalid value),isDisplayed (Invalid value),isSendingAlerts (Invalid value),isSendingVitals (Invalid value),language (Invalid value),reminderTimeout (Invalid value),fallbackTimeout (Invalid value)`,
+        `Bad request to /clients/${this.existingClient.id}: displayName (Invalid value),responderPhoneNumbers (Invalid value),fromPhoneNumber (Invalid value),incidentCategories (Invalid value),isDisplayed (Invalid value),isSendingAlerts (Invalid value),isSendingVitals (Invalid value),language (Invalid value),reminderTimeout (Invalid value),fallbackTimeout (Invalid value)`,
       )
     })
   })

--- a/server/test/integration/dashboardTest/submitNewClientTest.js
+++ b/server/test/integration/dashboardTest/submitNewClientTest.js
@@ -285,6 +285,78 @@ describe('dashboard.js integration tests: submitNewClient', () => {
     })
   })
 
+  describe('for a request that contains valid non-empty fields but with no fallbackPhoneNumbers', () => {
+    beforeEach(async () => {
+      await this.agent.post('/login').send({
+        username: helpers.getEnvVar('WEB_USERNAME'),
+        password: helpers.getEnvVar('PASSWORD'),
+      })
+
+      this.displayName = 'myNewClient'
+      this.fromPhoneNumber = '+19998887777'
+      this.responderPhoneNumbers = ['+16665553333']
+      this.heartbeatPhoneNumbers = ['+1', '+2', '+3']
+      this.incidentCategories = ['Cat1', 'Cat2']
+      this.reminderTimeout = 5
+      this.fallbackTimeout = 10
+      this.language = 'en'
+      const goodRequest = {
+        displayName: this.displayName,
+        fromPhoneNumber: this.fromPhoneNumber,
+        responderPhoneNumbers: this.responderPhoneNumbers.join(','),
+        heartbeatPhoneNumbers: this.heartbeatPhoneNumbers.join(','),
+        incidentCategories: this.incidentCategories.join(','),
+        reminderTimeout: this.reminderTimeout,
+        fallbackTimeout: this.fallbackTimeout,
+        language: this.language,
+      }
+
+      this.response = await this.agent.post('/clients').send(goodRequest)
+    })
+
+    it('should return 200', () => {
+      expect(this.response).to.have.status(200)
+    })
+
+    it('should create a single client in the database with the given values', async () => {
+      const clients = await db.getClients()
+
+      expect(
+        clients.map(client => {
+          return {
+            displayName: client.displayName,
+            fromPhoneNumber: client.fromPhoneNumber,
+            responderPhoneNumbers: client.responderPhoneNumbers,
+            fallbackPhoneNumbers: client.fallbackPhoneNumbers,
+            heartbeatPhoneNumbers: client.heartbeatPhoneNumbers,
+            incidentCategories: client.incidentCategories,
+            reminderTimeout: client.reminderTimeout,
+            fallbackTimeout: client.fallbackTimeout,
+            isDisplayed: client.isDisplayed,
+            isSendingAlerts: client.isSendingAlerts,
+            isSendingVitals: client.isSendingVitals,
+            language: client.language,
+          }
+        }),
+      ).to.eql([
+        {
+          displayName: this.displayName,
+          fromPhoneNumber: this.fromPhoneNumber,
+          responderPhoneNumbers: this.responderPhoneNumbers,
+          fallbackPhoneNumbers: [],
+          heartbeatPhoneNumbers: this.heartbeatPhoneNumbers,
+          incidentCategories: this.incidentCategories,
+          reminderTimeout: this.reminderTimeout,
+          fallbackTimeout: this.fallbackTimeout,
+          isDisplayed: true,
+          isSendingAlerts: false,
+          isSendingVitals: false,
+          language: this.language,
+        },
+      ])
+    })
+  })
+
   describe('for a request that contains valid non-empty fields but with no responderPhoneNumbers', () => {
     beforeEach(async () => {
       await this.agent.post('/login').send({
@@ -363,7 +435,7 @@ describe('dashboard.js integration tests: submitNewClient', () => {
 
     it('should log the error', () => {
       expect(helpers.log).to.have.been.calledWith(
-        'Bad request to /clients: displayName (Invalid value),responderPhoneNumbers (Invalid value),fallbackPhoneNumbers (Invalid value),fromPhoneNumber (Invalid value),language (Invalid value),incidentCategories (Invalid value),reminderTimeout (Invalid value),fallbackTimeout (Invalid value)',
+        'Bad request to /clients: displayName (Invalid value),responderPhoneNumbers (Invalid value),fromPhoneNumber (Invalid value),language (Invalid value),incidentCategories (Invalid value),reminderTimeout (Invalid value),fallbackTimeout (Invalid value)',
       )
     })
   })
@@ -390,7 +462,7 @@ describe('dashboard.js integration tests: submitNewClient', () => {
 
     it('should log the error', () => {
       expect(helpers.log).to.have.been.calledWith(
-        'Bad request to /clients: displayName (Invalid value),responderPhoneNumbers (Invalid value),fallbackPhoneNumbers (Invalid value),fromPhoneNumber (Invalid value),language (Invalid value),incidentCategories (Invalid value),reminderTimeout (Invalid value),fallbackTimeout (Invalid value)',
+        'Bad request to /clients: displayName (Invalid value),responderPhoneNumbers (Invalid value),fromPhoneNumber (Invalid value),language (Invalid value),incidentCategories (Invalid value),reminderTimeout (Invalid value),fallbackTimeout (Invalid value)',
       )
     })
   })


### PR DESCRIPTION
- Changed the sensors dashboard to make the fallback numbers optional for new and edit client
- Updated db query calls to handle empty array for fallback numbers
- Database defaults to {} empty array if we pass empty or undefined parameters for fallback numbers
- Added test cases for a request that contains valid non-empty fields but with no fallbackPhoneNumbers for both new client and edit client functions
