### PR TITLE
Make sensor server code compatible with multiple sensor types (CU-86duvwbq2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,16 @@ the code was deployed.
 
 ### Added
 
-- Added migration script to update device_type_enum to handle multistall and singlestall sensors seperately (CU-86duvwbq2).
+- Added migration script to update device_type_enum to handle multistall and singlestall sensors separately (CU-86duvwbq2).
+- Added dashboard functionality for submit new location and edit location to handle different device_types using dropdown (CU-86duvwbq2).
+- Added new integration tests for inserting a multi-stall sensor and editing single-stall to multi-stall (CU-86duvwbq2).
 
 ### Changed
 
 - Updated brave-alert-lib to v15.0.3 for deviceType enum change (CU-86duvwbq2).
-- Updated db functions to use 'DEVICE_SENSOR_SINGLESTALL' instead of 'DEVICE_SENSOR' (CU-86duvwbq2).
 - Updated device_type_enum to have 'DEVICE_SENSOR_SINGLESTALL' and 'DEVICE_SENSOR_MULTISTALL' instead of 'DEVICE_SENSOR' (CU-86duvwbq2).
+- Updated test cases for newLocation and updateLocation to use new device types (CU-86duvwbq2).
+- Updated the /pa/create-sensor-location route due to createLocationFromBrowserForm() db function change (CU-86duvwbq2).
 
 ## [10.15.0] - 2024-10-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ the code was deployed.
 
 ## [Unreleased]
 
+### Added
+
+- Added migration script to update device_type_enum to handle multistall and singlestall sensors seperately (CU-86duvwbq2).
+
+### Changed
+
+- Updated brave-alert-lib to v15.0.3 for deviceType enum change (CU-86duvwbq2).
+- Updated db functions to use 'DEVICE_SENSOR_SINGLESTALL' instead of 'DEVICE_SENSOR' (CU-86duvwbq2).
+- Updated device_type_enum to have 'DEVICE_SENSOR_SINGLESTALL' and 'DEVICE_SENSOR_MULTISTALL' instead of 'DEVICE_SENSOR' (CU-86duvwbq2).
+
 ## [10.15.0] - 2024-10-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ the code was deployed.
 
 ### Changed
 
-- Updated brave-alert-lib to v15.0.3 for deviceType enum change (CU-86duvwbq2).
+- Updated brave-alert-lib to v15.0.4 for deviceType enum change (CU-86duvwbq2).
 - Updated device_type_enum to have 'DEVICE_SENSOR_SINGLESTALL' and 'DEVICE_SENSOR_MULTISTALL' instead of 'DEVICE_SENSOR' (CU-86duvwbq2).
 - Updated test cases for newLocation and updateLocation to use new device types (CU-86duvwbq2).
 - Updated the /pa/create-sensor-location route due to createLocationFromBrowserForm() db function change (CU-86duvwbq2).

--- a/server/dashboard.js
+++ b/server/dashboard.js
@@ -360,6 +360,7 @@ async function renderClientDetailsPage(req, res) {
           return {
             name: location.displayName,
             id: location.id,
+            deviceType: location.deviceType,
             sessionStart: location.sessionStart,
             isSendingAlerts: location.isSendingAlerts && location.client.isSendingAlerts,
             isSendingVitals: location.isSendingVitals && location.client.isSendingVitals,

--- a/server/dashboard.js
+++ b/server/dashboard.js
@@ -285,8 +285,8 @@ async function renderLocationEditPage(req, res) {
             selected: client.id === location.client.id,
           }
         }),
-      isSingleStallSelected: location.deviceType === 'DEVICE_SENSOR_SINGLESTALL',
-      isMultiStallSelected: location.deviceType === 'DEVICE_SENSOR_MULTISTALL',
+      isSingleStallSelected: location.deviceType === 'SENSOR_SINGLESTALL',
+      isMultiStallSelected: location.deviceType === 'SENSOR_MULTISTALL',
     }
 
     res.send(Mustache.render(updateLocationTemplate, viewParams, { nav: navPartial, css: locationFormCSSPartial }))

--- a/server/dashboard.js
+++ b/server/dashboard.js
@@ -548,7 +548,7 @@ async function submitEditClient(req, res) {
   }
 }
 
-const validateNewLocation = Validator.body(['locationid', 'displayName', 'deviceType', 'serialNumber', 'phoneNumber', 'clientId']).trim().notEmpty()
+const validateNewLocation = Validator.body(['locationid', 'displayName', 'serialNumber', 'phoneNumber', 'clientId', 'deviceType']).trim().notEmpty()
 
 async function submitNewLocation(req, res) {
   try {

--- a/server/dashboard.js
+++ b/server/dashboard.js
@@ -548,7 +548,7 @@ async function submitEditClient(req, res) {
   }
 }
 
-const validateNewLocation = Validator.body(['locationid', 'displayName', 'serialNumber', 'phoneNumber', 'clientId']).trim().notEmpty()
+const validateNewLocation = Validator.body(['locationid', 'displayName', 'deviceType', 'serialNumber', 'phoneNumber', 'clientId']).trim().notEmpty()
 
 async function submitNewLocation(req, res) {
   try {
@@ -584,6 +584,7 @@ async function submitNewLocation(req, res) {
         data.serialNumber,
         data.phoneNumber,
         data.clientId,
+        data.deviceType,
       )
 
       res.redirect(`/locations/${newLocation.id}`)

--- a/server/dashboard.js
+++ b/server/dashboard.js
@@ -285,6 +285,8 @@ async function renderLocationEditPage(req, res) {
             selected: client.id === location.client.id,
           }
         }),
+      isSingleStallSelected: location.deviceType === "DEVICE_SENSOR_SINGLESTALL",
+      isMultiStallSelected: location.deviceType === "DEVICE_SENSOR_MULTISTALL",
     }
 
     res.send(Mustache.render(updateLocationTemplate, viewParams, { nav: navPartial, css: locationFormCSSPartial }))

--- a/server/dashboard.js
+++ b/server/dashboard.js
@@ -285,8 +285,8 @@ async function renderLocationEditPage(req, res) {
             selected: client.id === location.client.id,
           }
         }),
-      isSingleStallSelected: location.deviceType === "DEVICE_SENSOR_SINGLESTALL",
-      isMultiStallSelected: location.deviceType === "DEVICE_SENSOR_MULTISTALL",
+      isSingleStallSelected: location.deviceType === 'DEVICE_SENSOR_SINGLESTALL',
+      isMultiStallSelected: location.deviceType === 'DEVICE_SENSOR_MULTISTALL',
     }
 
     res.send(Mustache.render(updateLocationTemplate, viewParams, { nav: navPartial, css: locationFormCSSPartial }))

--- a/server/dashboard.js
+++ b/server/dashboard.js
@@ -607,6 +607,7 @@ const validateEditLocation = Validator.body([
   'isSendingAlerts',
   'isSendingVitals',
   'clientId',
+  'deviceType',
 ])
   .trim()
   .notEmpty()
@@ -640,6 +641,7 @@ async function submitEditLocation(req, res) {
         data.isSendingAlerts === 'true',
         data.isSendingVitals === 'true',
         data.clientId,
+        data.deviceType,
         data.deviceId,
       )
 

--- a/server/db/053-alter-deviceType-enum.sql
+++ b/server/db/053-alter-deviceType-enum.sql
@@ -12,7 +12,7 @@ BEGIN
     -- Only execute this script if its migration ID is next after the last successful migration ID
     IF migrationId - lastSuccessfulMigrationId = 1 THEN
         -- create a new enum type
-        -- note: BUTTON device type is noddt currently used in sensors db as database merge was retracted
+        -- note: BUTTON device type is not currently used in sensors db as database merge was retracted
         CREATE TYPE device_type_enum_new AS ENUM ('BUTTON', 'SENSOR_SINGLESTALL', 'SENSOR_MULTISTALL');
 
         -- add a temporary column with the new enum type

--- a/server/db/053-alter-deviceType-enum.sql
+++ b/server/db/053-alter-deviceType-enum.sql
@@ -1,52 +1,3 @@
-BEGIN;
-
-DO $testdevice$
-DECLARE
-    client_id UUID;
-BEGIN
-    -- fetch the client_id from the clients table
-    SELECT id INTO client_id
-    FROM public.clients
-    WHERE display_name = 'TempInitialClient'
-    LIMIT 1;
-
-    -- insert a new device using the fetched client_id
-    INSERT INTO public.devices (
-        locationid,
-        phone_number,
-        display_name,
-        serial_number,
-        client_id,
-        sent_low_battery_alert_at,
-        sent_vitals_alert_at,
-        created_at,
-        updated_at,
-        is_displayed,
-        is_sending_alerts,
-        is_sending_vitals,
-        id,
-        device_type
-    ) VALUES (
-        'TEST_1',                                -- locationid
-        '+15555555555',                          -- phone_number
-        'Test_1',                                -- display_name
-        'e00123456789123456789123',              -- serial_number
-        client_id,                               -- dynamically fetched client_id
-        NULL,                                    -- sent_low_battery_alert_at
-        NULL,                                    -- sent_vitals_alert_at
-        NOW(),                                   -- created_at
-        NOW(),                                   -- updated_at
-        TRUE,                                    -- is_displayed
-        TRUE,                                    -- is_sending_alerts
-        TRUE,                                    -- is_sending_vitals
-        gen_random_uuid(),                       -- id
-        'DEVICE_SENSOR'                          -- device_type
-    );
-END $testdevice$;
-
--- show inserted test devices before migration 
-SELECT * FROM devices;
-
 DO $migration$
     DECLARE migrationId INT;
     DECLARE lastSuccessfulMigrationId INT;
@@ -87,9 +38,3 @@ BEGIN
         VALUES (migrationId);
     END IF;
 END $migration$;
-
--- show all devices after the migration
-SELECT * FROM devices;
-
--- don't commit the transaction, undo this script
-ROLLBACK;

--- a/server/db/053-alter-deviceType-enum.sql
+++ b/server/db/053-alter-deviceType-enum.sql
@@ -38,3 +38,4 @@ BEGIN
         VALUES (migrationId);
     END IF;
 END $migration$;
+

--- a/server/db/053-alter-deviceType-enum.sql
+++ b/server/db/053-alter-deviceType-enum.sql
@@ -38,4 +38,3 @@ BEGIN
         VALUES (migrationId);
     END IF;
 END $migration$;
-

--- a/server/db/053-alter-deviceType-enum.sql
+++ b/server/db/053-alter-deviceType-enum.sql
@@ -1,0 +1,95 @@
+BEGIN;
+
+DO $testdevice$
+DECLARE
+    client_id UUID;
+BEGIN
+    -- fetch the client_id from the clients table
+    SELECT id INTO client_id
+    FROM public.clients
+    WHERE display_name = 'TempInitialClient'
+    LIMIT 1;
+
+    -- insert a new device using the fetched client_id
+    INSERT INTO public.devices (
+        locationid,
+        phone_number,
+        display_name,
+        serial_number,
+        client_id,
+        sent_low_battery_alert_at,
+        sent_vitals_alert_at,
+        created_at,
+        updated_at,
+        is_displayed,
+        is_sending_alerts,
+        is_sending_vitals,
+        id,
+        device_type
+    ) VALUES (
+        'TEST_1',                                -- locationid
+        '+15555555555',                          -- phone_number
+        'Test_1',                                -- display_name
+        'e00123456789123456789123',              -- serial_number
+        client_id,                               -- dynamically fetched client_id
+        NULL,                                    -- sent_low_battery_alert_at
+        NULL,                                    -- sent_vitals_alert_at
+        NOW(),                                   -- created_at
+        NOW(),                                   -- updated_at
+        TRUE,                                    -- is_displayed
+        TRUE,                                    -- is_sending_alerts
+        TRUE,                                    -- is_sending_vitals
+        gen_random_uuid(),                       -- id
+        'DEVICE_SENSOR'                          -- device_type
+    );
+END $testdevice$;
+
+-- show inserted test devices before migration 
+SELECT * FROM devices;
+
+DO $migration$
+    DECLARE migrationId INT;
+    DECLARE lastSuccessfulMigrationId INT;
+BEGIN
+    -- The migration ID of this file
+    migrationId := 53;
+
+    -- Get the migration ID of the last file to be successfully run
+    SELECT MAX(id) INTO lastSuccessfulMigrationId
+    FROM migrations;
+
+    -- Only execute this script if its migration ID is next after the last successful migration ID
+    IF migrationId - lastSuccessfulMigrationId = 1 THEN
+        -- create a new enum type
+        CREATE TYPE device_type_enum_new AS ENUM ('DEVICE_BUTTON', 'DEVICE_SENSOR_SINGLESTALL', 'DEVICE_SENSOR_MULTISTALL');
+
+        -- add a temporary column with the new enum type
+        ALTER TABLE devices ADD COLUMN device_type_new device_type_enum_new;
+
+        -- migrate data to the new column, set existing sensors to singlestall
+        UPDATE devices
+        SET device_type_new = 
+            CASE 
+                WHEN device_type = 'DEVICE_SENSOR' THEN 'DEVICE_SENSOR_SINGLESTALL'
+                ELSE device_type::text::device_type_enum_new
+            END;
+
+        -- drop the old column and rename the new column
+        ALTER TABLE devices DROP COLUMN device_type;
+        ALTER TABLE devices RENAME COLUMN device_type_new TO device_type;
+
+        -- drop the old enum type and rename the new enum type to the original name 
+        DROP TYPE device_type_enum;
+        ALTER TYPE device_type_enum_new RENAME TO device_type_enum;
+
+        -- Update the migration ID of the last file to be successfully run to the migration ID of this file
+        INSERT INTO migrations (id)
+        VALUES (migrationId);
+    END IF;
+END $migration$;
+
+-- show all devices after the migration
+SELECT * FROM devices;
+
+-- don't commit the transaction, undo this script
+ROLLBACK;

--- a/server/db/053-alter-deviceType-enum.sql
+++ b/server/db/053-alter-deviceType-enum.sql
@@ -12,6 +12,7 @@ BEGIN
     -- Only execute this script if its migration ID is next after the last successful migration ID
     IF migrationId - lastSuccessfulMigrationId = 1 THEN
         -- create a new enum type
+        -- note: BUTTON device type is noddt currently used in sensors db as database merge was retracted
         CREATE TYPE device_type_enum_new AS ENUM ('BUTTON', 'SENSOR_SINGLESTALL', 'SENSOR_MULTISTALL');
 
         -- add a temporary column with the new enum type

--- a/server/db/053-alter-deviceType-enum.sql
+++ b/server/db/053-alter-deviceType-enum.sql
@@ -12,7 +12,7 @@ BEGIN
     -- Only execute this script if its migration ID is next after the last successful migration ID
     IF migrationId - lastSuccessfulMigrationId = 1 THEN
         -- create a new enum type
-        CREATE TYPE device_type_enum_new AS ENUM ('DEVICE_BUTTON', 'DEVICE_SENSOR_SINGLESTALL', 'DEVICE_SENSOR_MULTISTALL');
+        CREATE TYPE device_type_enum_new AS ENUM ('BUTTON', 'SENSOR_SINGLESTALL', 'SENSOR_MULTISTALL');
 
         -- add a temporary column with the new enum type
         ALTER TABLE devices ADD COLUMN device_type_new device_type_enum_new;
@@ -21,7 +21,7 @@ BEGIN
         UPDATE devices
         SET device_type_new = 
             CASE 
-                WHEN device_type = 'DEVICE_SENSOR' THEN 'DEVICE_SENSOR_SINGLESTALL'
+                WHEN device_type = 'DEVICE_SENSOR' THEN 'SENSOR_SINGLESTALL'
                 ELSE device_type::text::device_type_enum_new
             END;
 

--- a/server/db/053-alter-deviceType-enum.sql
+++ b/server/db/053-alter-deviceType-enum.sql
@@ -22,6 +22,7 @@ BEGIN
         SET device_type_new = 
             CASE 
                 WHEN device_type = 'DEVICE_SENSOR' THEN 'SENSOR_SINGLESTALL'
+                WHEN device_type = 'DEVICE_BUTTON' THEN 'BUTTON'
                 ELSE device_type::text::device_type_enum_new
             END;
 

--- a/server/db/db.js
+++ b/server/db/db.js
@@ -1119,16 +1119,15 @@ async function updateClientExtension(clientId, country, countrySubdivision, buil
 
 // Adds a location table entry from browser form, named this way with an extra word because "FromForm" is hard to read
 // prettier-ignore
-async function createLocationFromBrowserForm(locationid, displayName, serialNumber, phoneNumber, clientId, pgClient) {
+async function createLocationFromBrowserForm(locationid, displayName, serialNumber, phoneNumber, clientId, deviceType, pgClient) {
   try {
     const results = await helpers.runQuery('createLocationFromBrowserForm',
       `
-      INSERT INTO devices(device_type, locationid, display_name, serial_number, phone_number, is_displayed, is_sending_alerts, is_sending_vitals, client_id)
+      INSERT INTO devices(locationid, display_name, serial_number, phone_number, is_displayed, is_sending_alerts, is_sending_vitals, client_id, device_type)
       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
       RETURNING *
       `,
       [
-        DEVICE_TYPE.DEVICE_SENSOR_SINGLESTALL,
         locationid,
         displayName,
         serialNumber,
@@ -1137,6 +1136,7 @@ async function createLocationFromBrowserForm(locationid, displayName, serialNumb
         false,
         false,
         clientId,
+        deviceType,
       ],
       pool,
       pgClient,

--- a/server/db/db.js
+++ b/server/db/db.js
@@ -372,9 +372,9 @@ async function getDataForExport(pgClient) {
         LEFT JOIN devices d ON s.device_id = d.id
         LEFT JOIN clients c on d.client_id = c.id
         LEFT JOIN clients_extension x on x.client_id = c.id
-        WHERE d.device_type = $1
+        WHERE device_type IN ($1, $2)
       `,
-      [DEVICE_TYPE.DEVICE_SENSOR_SINGLESTALL],
+      [DEVICE_TYPE.DEVICE_SENSOR_SINGLESTALL, DEVICE_TYPE.DEVICE_SENSOR_MULTISTALL],
       pool,
       pgClient,
     )

--- a/server/db/db.js
+++ b/server/db/db.js
@@ -326,7 +326,7 @@ async function getLocations(pgClient) {
       SELECT d.*
       FROM devices AS d
       LEFT JOIN clients AS c ON d.client_id = c.id
-      WHERE device_type IN ($1, $2)
+      WHERE d.device_type IN ($1, $2)
       ORDER BY c.display_name, d.display_name
       `,
       [DEVICE_TYPE.DEVICE_SENSOR_SINGLESTALL, DEVICE_TYPE.DEVICE_SENSOR_MULTISTALL],
@@ -372,7 +372,7 @@ async function getDataForExport(pgClient) {
         LEFT JOIN devices d ON s.device_id = d.id
         LEFT JOIN clients c on d.client_id = c.id
         LEFT JOIN clients_extension x on x.client_id = c.id
-        WHERE device_type IN ($1, $2)
+        WHERE d.device_type IN ($1, $2)
       `,
       [DEVICE_TYPE.DEVICE_SENSOR_SINGLESTALL, DEVICE_TYPE.DEVICE_SENSOR_MULTISTALL],
       pool,

--- a/server/db/db.js
+++ b/server/db/db.js
@@ -913,10 +913,10 @@ async function getLocationsFromClientId(clientId, pgClient) {
       SELECT *
       FROM devices
       WHERE client_id = $1
-      AND device_type = $2
+      AND device_type IN ($2, $3)
       ORDER BY display_name
       `,
-      [clientId, DEVICE_TYPE.DEVICE_SENSOR_SINGLESTALL],
+      [clientId, DEVICE_TYPE.DEVICE_SENSOR_SINGLESTALL, DEVICE_TYPE.DEVICE_SENSOR_MULTISTALL],
       pool,
       pgClient,
     )

--- a/server/db/db.js
+++ b/server/db/db.js
@@ -250,7 +250,7 @@ async function getActiveSensorClients(pgClient) {
       WHERE c.is_sending_alerts AND c.is_sending_vitals
       ORDER BY c.display_name;
       `,
-      [DEVICE_TYPE.DEVICE_SENSOR],
+      [DEVICE_TYPE.DEVICE_SENSOR_SINGLESTALL],
       pool,
       pgClient,
     )
@@ -328,7 +328,7 @@ async function getLocations(pgClient) {
       WHERE d.device_type = $1
       ORDER BY c.display_name, d.display_name
       `,
-      [DEVICE_TYPE.DEVICE_SENSOR],
+      [DEVICE_TYPE.DEVICE_SENSOR_SINGLESTALL],
       pool,
       pgClient,
     )
@@ -373,7 +373,7 @@ async function getDataForExport(pgClient) {
         LEFT JOIN clients_extension x on x.client_id = c.id
         WHERE d.device_type = $1
       `,
-      [DEVICE_TYPE.DEVICE_SENSOR],
+      [DEVICE_TYPE.DEVICE_SENSOR_SINGLESTALL],
       pool,
       pgClient,
     )
@@ -915,7 +915,7 @@ async function getLocationsFromClientId(clientId, pgClient) {
       AND device_type = $2
       ORDER BY display_name
       `,
-      [clientId, DEVICE_TYPE.DEVICE_SENSOR],
+      [clientId, DEVICE_TYPE.DEVICE_SENSOR_SINGLESTALL],
       pool,
       pgClient,
     )
@@ -1127,7 +1127,7 @@ async function createLocationFromBrowserForm(locationid, displayName, serialNumb
       RETURNING *
       `,
       [
-        DEVICE_TYPE.DEVICE_SENSOR,
+        DEVICE_TYPE.DEVICE_SENSOR_SINGLESTALL,
         locationid,
         displayName,
         serialNumber,
@@ -1177,7 +1177,7 @@ async function createLocation(
       RETURNING *
       `,
       [
-        DEVICE_TYPE.DEVICE_SENSOR,
+        DEVICE_TYPE.DEVICE_SENSOR_SINGLESTALL,
         locationid,
         sentVitalsAlertAt,
         phoneNumber,
@@ -1262,7 +1262,7 @@ async function getRecentSensorsVitals(pgClient) {
       WHERE d.device_type = $1
       ORDER BY sv.created_at
       `,
-      [DEVICE_TYPE.DEVICE_SENSOR],
+      [DEVICE_TYPE.DEVICE_SENSOR_SINGLESTALL],
       pool,
       pgClient,
     )

--- a/server/db/db.js
+++ b/server/db/db.js
@@ -1157,7 +1157,7 @@ async function createLocationFromBrowserForm(locationid, displayName, serialNumb
   }
 }
 
-// Adds a location table entry
+// Adds a singlestall location table entry
 async function createLocation(
   locationid,
   sentVitalsAlertAt,
@@ -1169,18 +1169,18 @@ async function createLocation(
   isSendingVitals,
   sentLowBatteryAlertAt,
   clientId,
+  deviceType,
   pgClient,
 ) {
   try {
     const results = await helpers.runQuery(
       'createLocation',
       `
-      INSERT INTO devices(device_type, locationid, sent_vitals_alert_at, phone_number, display_name, serial_number, is_displayed, is_sending_alerts, is_sending_vitals, sent_low_battery_alert_at, client_id)
+      INSERT INTO devices(locationid, sent_vitals_alert_at, phone_number, display_name, serial_number, is_displayed, is_sending_alerts, is_sending_vitals, sent_low_battery_alert_at, client_id, device_type)
       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
       RETURNING *
       `,
       [
-        DEVICE_TYPE.DEVICE_SENSOR_SINGLESTALL,
         locationid,
         sentVitalsAlertAt,
         phoneNumber,
@@ -1191,6 +1191,7 @@ async function createLocation(
         isSendingVitals,
         sentLowBatteryAlertAt,
         clientId,
+        deviceType,
       ],
       pool,
       pgClient,

--- a/server/db/db.js
+++ b/server/db/db.js
@@ -1263,10 +1263,10 @@ async function getRecentSensorsVitals(pgClient) {
       SELECT d.locationid, sv.id, sv.missed_door_messages, sv.is_door_battery_low, sv.door_last_seen_at, sv.reset_reason, sv.state_transitions, sv.created_at, sv.is_tampered
       FROM devices d
       LEFT JOIN sensors_vitals_cache sv on d.locationid = sv.locationid
-      WHERE d.device_type = $1
+      WHERE d.device_type IN ($1, $2)
       ORDER BY sv.created_at
       `,
-      [DEVICE_TYPE.DEVICE_SENSOR_SINGLESTALL],
+      [DEVICE_TYPE.DEVICE_SENSOR_SINGLESTALL, DEVICE_TYPE.DEVICE_SENSOR_MULTISTALL],
       pool,
       pgClient,
     )
@@ -1291,9 +1291,10 @@ async function getRecentSensorsVitalsWithClientId(clientId, pgClient) {
       FROM devices d
       LEFT JOIN sensors_vitals_cache sv on sv.locationid = d.locationid
       WHERE d.client_id = $1
+      AND d.device_type IN ($2, $3)
       ORDER BY sv.created_at
       `,
-      [clientId],
+      [clientId, DEVICE_TYPE.DEVICE_SENSOR_SINGLESTALL, DEVICE_TYPE.DEVICE_SENSOR_MULTISTALL],
       pool,
       pgClient,
     )

--- a/server/db/db.js
+++ b/server/db/db.js
@@ -12,7 +12,8 @@ const pool = new pg.Pool({
   user: helpers.getEnvVar('PG_USER'),
   database: helpers.getEnvVar('PG_DATABASE'),
   password: helpers.getEnvVar('PG_PASSWORD'),
-  ssl: { rejectUnauthorized: false },
+  ssl: false,
+  // ssl: { rejectUnauthorized: false },
 })
 
 // 1114 is OID for timestamp in Postgres
@@ -242,7 +243,7 @@ async function getActiveSensorClients(pgClient) {
       INNER JOIN (
         SELECT DISTINCT client_id AS id
         FROM devices
-        WHERE device_type = $1
+        WHERE device_type IN ($1, $2)
         AND is_sending_alerts
         AND is_sending_vitals
       ) AS d
@@ -250,7 +251,7 @@ async function getActiveSensorClients(pgClient) {
       WHERE c.is_sending_alerts AND c.is_sending_vitals
       ORDER BY c.display_name;
       `,
-      [DEVICE_TYPE.DEVICE_SENSOR_SINGLESTALL],
+      [DEVICE_TYPE.DEVICE_SENSOR_SINGLESTALL, DEVICE_TYPE.DEVICE_SENSOR_MULTISTALL],
       pool,
       pgClient,
     )

--- a/server/db/db.js
+++ b/server/db/db.js
@@ -326,10 +326,10 @@ async function getLocations(pgClient) {
       SELECT d.*
       FROM devices AS d
       LEFT JOIN clients AS c ON d.client_id = c.id
-      WHERE d.device_type = $1
+      WHERE device_type IN ($1, $2)
       ORDER BY c.display_name, d.display_name
       `,
-      [DEVICE_TYPE.DEVICE_SENSOR_SINGLESTALL],
+      [DEVICE_TYPE.DEVICE_SENSOR_SINGLESTALL, DEVICE_TYPE.DEVICE_SENSOR_MULTISTALL],
       pool,
       pgClient,
     )

--- a/server/db/db.js
+++ b/server/db/db.js
@@ -250,7 +250,7 @@ async function getActiveSensorClients(pgClient) {
       WHERE c.is_sending_alerts AND c.is_sending_vitals
       ORDER BY c.display_name;
       `,
-      [DEVICE_TYPE.DEVICE_SENSOR_SINGLESTALL, DEVICE_TYPE.DEVICE_SENSOR_MULTISTALL],
+      [DEVICE_TYPE.SENSOR_SINGLESTALL, DEVICE_TYPE.SENSOR_MULTISTALL],
       pool,
       pgClient,
     )
@@ -328,7 +328,7 @@ async function getLocations(pgClient) {
       WHERE d.device_type IN ($1, $2)
       ORDER BY c.display_name, d.display_name
       `,
-      [DEVICE_TYPE.DEVICE_SENSOR_SINGLESTALL, DEVICE_TYPE.DEVICE_SENSOR_MULTISTALL],
+      [DEVICE_TYPE.SENSOR_SINGLESTALL, DEVICE_TYPE.SENSOR_MULTISTALL],
       pool,
       pgClient,
     )
@@ -373,7 +373,7 @@ async function getDataForExport(pgClient) {
         LEFT JOIN clients_extension x on x.client_id = c.id
         WHERE d.device_type IN ($1, $2)
       `,
-      [DEVICE_TYPE.DEVICE_SENSOR_SINGLESTALL, DEVICE_TYPE.DEVICE_SENSOR_MULTISTALL],
+      [DEVICE_TYPE.SENSOR_SINGLESTALL, DEVICE_TYPE.SENSOR_MULTISTALL],
       pool,
       pgClient,
     )
@@ -915,7 +915,7 @@ async function getLocationsFromClientId(clientId, pgClient) {
       AND device_type IN ($2, $3)
       ORDER BY display_name
       `,
-      [clientId, DEVICE_TYPE.DEVICE_SENSOR_SINGLESTALL, DEVICE_TYPE.DEVICE_SENSOR_MULTISTALL],
+      [clientId, DEVICE_TYPE.SENSOR_SINGLESTALL, DEVICE_TYPE.SENSOR_MULTISTALL],
       pool,
       pgClient,
     )
@@ -1265,7 +1265,7 @@ async function getRecentSensorsVitals(pgClient) {
       WHERE d.device_type IN ($1, $2)
       ORDER BY sv.created_at
       `,
-      [DEVICE_TYPE.DEVICE_SENSOR_SINGLESTALL, DEVICE_TYPE.DEVICE_SENSOR_MULTISTALL],
+      [DEVICE_TYPE.SENSOR_SINGLESTALL, DEVICE_TYPE.SENSOR_MULTISTALL],
       pool,
       pgClient,
     )
@@ -1293,7 +1293,7 @@ async function getRecentSensorsVitalsWithClientId(clientId, pgClient) {
       AND d.device_type IN ($2, $3)
       ORDER BY sv.created_at
       `,
-      [clientId, DEVICE_TYPE.DEVICE_SENSOR_SINGLESTALL, DEVICE_TYPE.DEVICE_SENSOR_MULTISTALL],
+      [clientId, DEVICE_TYPE.SENSOR_SINGLESTALL, DEVICE_TYPE.SENSOR_MULTISTALL],
       pool,
       pgClient,
     )

--- a/server/db/db.js
+++ b/server/db/db.js
@@ -971,6 +971,7 @@ async function updateLocation(
   isSendingAlerts,
   isSendingVitals,
   clientId,
+  deviceType,
   deviceId,
   pgClient,
 ) {
@@ -986,11 +987,12 @@ async function updateLocation(
         is_displayed = $4,
         is_sending_alerts = $5,
         is_sending_vitals = $6,
-        client_id = $7
-      WHERE id = $8
+        client_id = $7,
+        device_type = $8
+      WHERE id = $9
       RETURNING *
       `,
-      [displayName, serialNumber, phoneNumber, isDisplayed, isSendingAlerts, isSendingVitals, clientId, deviceId],
+      [displayName, serialNumber, phoneNumber, isDisplayed, isSendingAlerts, isSendingVitals, clientId, deviceType, deviceId],
       pool,
       pgClient,
     )

--- a/server/db/db.js
+++ b/server/db/db.js
@@ -12,8 +12,7 @@ const pool = new pg.Pool({
   user: helpers.getEnvVar('PG_USER'),
   database: helpers.getEnvVar('PG_DATABASE'),
   password: helpers.getEnvVar('PG_PASSWORD'),
-  ssl: false,
-  // ssl: { rejectUnauthorized: false },
+  ssl: { rejectUnauthorized: false },
 })
 
 // 1114 is OID for timestamp in Postgres

--- a/server/index.js
+++ b/server/index.js
@@ -90,6 +90,7 @@ app.post('/smokeTest/setup', async (request, response) => {
       true,
       '2021-03-09T19:37:28.176Z',
       client.id,
+      'DEVICE_SENSOR_SINGLESTALL'
     )
     response.status(200).send()
   } catch (error) {

--- a/server/index.js
+++ b/server/index.js
@@ -90,7 +90,7 @@ app.post('/smokeTest/setup', async (request, response) => {
       true,
       '2021-03-09T19:37:28.176Z',
       client.id,
-      'DEVICE_SENSOR_SINGLESTALL',
+      'SENSOR_SINGLESTALL',
     )
     response.status(200).send()
   } catch (error) {

--- a/server/index.js
+++ b/server/index.js
@@ -90,7 +90,7 @@ app.post('/smokeTest/setup', async (request, response) => {
       true,
       '2021-03-09T19:37:28.176Z',
       client.id,
-      'DEVICE_SENSOR_SINGLESTALL'
+      'DEVICE_SENSOR_SINGLESTALL',
     )
     response.status(200).send()
   } catch (error) {

--- a/server/mustache-templates/clientPage.mst
+++ b/server/mustache-templates/clientPage.mst
@@ -30,6 +30,7 @@
                         <thead>
                             <tr class="table-header" scope="row">
                                 <th scope="col"><h5>Location</h5></th>
+                                <th scope="col"><h5>Location Type</h5></th>
                                 <th scope="col"><h5>Last Session Started</h5></th>
                                 <th scope="col">Sends Alerts?</th>
                                 <th scope="col">Sends Vitals?</th>
@@ -39,6 +40,7 @@
                         {{#locations}}
                             <tr class="table-data">
                                 <th scope="row"><a href="/locations/{{id}}">{{name}}</a></th>
+                                <td>{{deviceType}}</td>
                                 <td>{{sessionStart}}</td>
                                 <td>{{#isSendingAlerts}}y{{/isSendingAlerts}}{{^isSendingAlerts}}NOPE{{/isSendingAlerts}}</td>
                                 <td>{{#isSendingVitals}}y{{/isSendingVitals}}{{^isSendingVitals}}NOPE{{/isSendingVitals}}</td>

--- a/server/mustache-templates/clientPage.mst
+++ b/server/mustache-templates/clientPage.mst
@@ -30,7 +30,7 @@
                         <thead>
                             <tr class="table-header" scope="row">
                                 <th scope="col"><h5>Location</h5></th>
-                                <th scope="col"><h5>Location Type</h5></th>
+                                <th scope="col"><h5>Device Type</h5></th>
                                 <th scope="col"><h5>Last Session Started</h5></th>
                                 <th scope="col">Sends Alerts?</th>
                                 <th scope="col">Sends Vitals?</th>

--- a/server/mustache-templates/newLocation.mst
+++ b/server/mustache-templates/newLocation.mst
@@ -35,6 +35,15 @@
                     </div>
                 </div>
                 <div class="form-group row justify-content-start row-no-gutters">
+                    <label for="deviceType" class="col-sm-3 col-form-label">Device Type:</label>
+                    <div class="col-sm-5">
+                        <select class="form-control" name="deviceType" required>
+                            <option value="DEVICE_SENSOR_SINGLESTALL">Single-Stall Sensor</option>
+                            <option value="DEVICE_SENSOR_MULTISTALL">Multi-Stall Sensor</option>
+                        </select>
+                    </div>
+                </div>
+                <div class="form-group row justify-content-start row-no-gutters">
                     <label for="clientId" class="col-sm-3 col-form-label">Client:</label>
                     <div class="col-sm-5">
                         <select class="form-control" name="clientId" required>

--- a/server/mustache-templates/newLocation.mst
+++ b/server/mustache-templates/newLocation.mst
@@ -35,15 +35,6 @@
                     </div>
                 </div>
                 <div class="form-group row justify-content-start row-no-gutters">
-                    <label for="deviceType" class="col-sm-3 col-form-label">Device Type:</label>
-                    <div class="col-sm-5">
-                        <select class="form-control" name="deviceType" required>
-                            <option value="DEVICE_SENSOR_SINGLESTALL">Single-Stall Sensor</option>
-                            <option value="DEVICE_SENSOR_MULTISTALL">Multi-Stall Sensor</option>
-                        </select>
-                    </div>
-                </div>
-                <div class="form-group row justify-content-start row-no-gutters">
                     <label for="clientId" class="col-sm-3 col-form-label">Client:</label>
                     <div class="col-sm-5">
                         <select class="form-control" name="clientId" required>
@@ -64,6 +55,15 @@
                     <div class="col-sm-5">
                         <input type="text" class="form-control" name="phoneNumber" value="+1" required pattern="[+][1]\d{10}">
                         <small id="phoneNumberHelp" class="form-text text-muted">+1 in front and no dashes or other delimiters, please (eg. +14445556789)</small>
+                    </div>
+                </div>
+                <div class="form-group row justify-content-start row-no-gutters">
+                    <label for="deviceType" class="col-sm-3 col-form-label">Device Type:</label>
+                    <div class="col-sm-5">
+                        <select class="form-control" name="deviceType" required>
+                            <option value="DEVICE_SENSOR_SINGLESTALL">Single-Stall Sensor</option>
+                            <option value="DEVICE_SENSOR_MULTISTALL">Multi-Stall Sensor</option>
+                        </select>
                     </div>
                 </div>
                 <br>

--- a/server/mustache-templates/newLocation.mst
+++ b/server/mustache-templates/newLocation.mst
@@ -48,8 +48,8 @@
                     <label for="deviceType" class="col-sm-3 col-form-label">Device Type:</label>
                     <div class="col-sm-5">
                         <select class="form-control" name="deviceType" required>
-                            <option value="DEVICE_SENSOR_SINGLESTALL">Single-Stall Sensor</option>
-                            <option value="DEVICE_SENSOR_MULTISTALL">Multi-Stall Sensor</option>
+                            <option value="SENSOR_SINGLESTALL">Single-Stall Sensor</option>
+                            <option value="SENSOR_MULTISTALL">Multi-Stall Sensor</option>
                         </select>
                     </div>
                 </div>

--- a/server/mustache-templates/newLocation.mst
+++ b/server/mustache-templates/newLocation.mst
@@ -45,6 +45,15 @@
                     </div>
                 </div>
                 <div class="form-group row justify-content-start row-no-gutters">
+                    <label for="deviceType" class="col-sm-3 col-form-label">Device Type:</label>
+                    <div class="col-sm-5">
+                        <select class="form-control" name="deviceType" required>
+                            <option value="DEVICE_SENSOR_SINGLESTALL">Single-Stall Sensor</option>
+                            <option value="DEVICE_SENSOR_MULTISTALL">Multi-Stall Sensor</option>
+                        </select>
+                    </div>
+                </div>
+                <div class="form-group row justify-content-start row-no-gutters">
                     <label for="radarCoreID" class="col-sm-3 col-form-label">Radar Particle Core ID:</label>
                     <div class="col-sm-5">
                         <input type="text" class="form-control" name="serialNumber" placeholder="Radar Particle Core ID" required>
@@ -55,15 +64,6 @@
                     <div class="col-sm-5">
                         <input type="text" class="form-control" name="phoneNumber" value="+1" required pattern="[+][1]\d{10}">
                         <small id="phoneNumberHelp" class="form-text text-muted">+1 in front and no dashes or other delimiters, please (eg. +14445556789)</small>
-                    </div>
-                </div>
-                <div class="form-group row justify-content-start row-no-gutters">
-                    <label for="deviceType" class="col-sm-3 col-form-label">Device Type:</label>
-                    <div class="col-sm-5">
-                        <select class="form-control" name="deviceType" required>
-                            <option value="DEVICE_SENSOR_SINGLESTALL">Single-Stall Sensor</option>
-                            <option value="DEVICE_SENSOR_MULTISTALL">Multi-Stall Sensor</option>
-                        </select>
                     </div>
                 </div>
                 <br>

--- a/server/mustache-templates/updateLocation.mst
+++ b/server/mustache-templates/updateLocation.mst
@@ -50,6 +50,15 @@
                     </div>
                 </div>
                 <div class="form-group row justify-content-start row-no-gutters">
+                    <label for="deviceType" class="col-sm-3 col-form-label">Device Type:</label>
+                    <div class="col-sm-5">
+                        <select class="form-control" name="deviceType" required>
+                            <option {{#isSingleStallSelected}} selected {{/isSingleStallSelected}} value="DEVICE_SENSOR_SINGLESTALL">Single-Stall Sensor</option>
+                            <option {{#isMultiStallSelected}} selected {{/isMultiStallSelected}} value="DEVICE_SENSOR_MULTISTALL">Multi-Stall Sensor</option>
+                        </select>
+                    </div>
+                </div>
+                <div class="form-group row justify-content-start row-no-gutters">
                     <label for="radarCoreID" class="col-sm-3 col-form-label">Radar Particle Core ID:</label>
                     <div class="col-sm-5">
                         <input type="text" class="form-control" name="serialNumber" placeholder="Radar Particle Core ID" value="{{serialNumber}}" required>
@@ -81,15 +90,6 @@
                     <div class="col-sm-5">
                         <input type="text" class="form-control" name="isSendingVitals" value="{{isSendingVitals}}" required pattern="(true|false)">
                         <small id="isSendingVitalsHelp" class="form-text text-muted">"true" or "false"</small>
-                    </div>
-                </div>
-                <div class="form-group row justify-content-start row-no-gutters">
-                    <label for="deviceType" class="col-sm-3 col-form-label">Device Type:</label>
-                    <div class="col-sm-5">
-                        <select class="form-control" name="deviceType" required>
-                            <option value="DEVICE_SENSOR_SINGLESTALL" {{#isSingleStallSelected}}selected{{/isSingleStallSelected}}>Single-Stall Sensor</option>
-                            <option value="DEVICE_SENSOR_MULTISTALL" {{#isMultiStallSelected}}selected{{/isMultiStallSelected}}>Multi-Stall Sensor</option>
-                        </select>
                     </div>
                 </div>
                 <br>

--- a/server/mustache-templates/updateLocation.mst
+++ b/server/mustache-templates/updateLocation.mst
@@ -83,6 +83,15 @@
                         <small id="isSendingVitalsHelp" class="form-text text-muted">"true" or "false"</small>
                     </div>
                 </div>
+                <div class="form-group row justify-content-start row-no-gutters">
+                    <label for="deviceType" class="col-sm-3 col-form-label">Device Type:</label>
+                    <div class="col-sm-5">
+                        <select class="form-control" name="deviceType" required>
+                            <option value="DEVICE_SENSOR_SINGLESTALL" {{#isSingleStallSelected}}selected{{/isSingleStallSelected}}>Single-Stall Sensor</option>
+                            <option value="DEVICE_SENSOR_MULTISTALL" {{#isMultiStallSelected}}selected{{/isMultiStallSelected}}>Multi-Stall Sensor</option>
+                        </select>
+                    </div>
+                </div>
                 <br>
                 <button type="submit" class="btn btn-primary btn-large">Submit</button>
               </form>

--- a/server/mustache-templates/updateLocation.mst
+++ b/server/mustache-templates/updateLocation.mst
@@ -53,8 +53,8 @@
                     <label for="deviceType" class="col-sm-3 col-form-label">Device Type:</label>
                     <div class="col-sm-5">
                         <select class="form-control" name="deviceType" required>
-                            <option {{#isSingleStallSelected}} selected {{/isSingleStallSelected}} value="DEVICE_SENSOR_SINGLESTALL">Single-Stall Sensor</option>
-                            <option {{#isMultiStallSelected}} selected {{/isMultiStallSelected}} value="DEVICE_SENSOR_MULTISTALL">Multi-Stall Sensor</option>
+                            <option {{#isSingleStallSelected}} selected {{/isSingleStallSelected}} value="SENSOR_SINGLESTALL">Single-Stall Sensor</option>
+                            <option {{#isMultiStallSelected}} selected {{/isMultiStallSelected}} value="SENSOR_MULTISTALL">Multi-Stall Sensor</option>
                         </select>
                     </div>
                 </div>

--- a/server/pa.js
+++ b/server/pa.js
@@ -60,16 +60,17 @@ async function handleCreateSensorLocation(req, res) {
   if (validationErrors.isEmpty()) {
     const braveAPIKey = req.body.braveKey
     const password = req.body.password
+
     const locationID = req.body.locationID
     const displayName = req.body.displayName
-    const deviceType = req.body.deviceType
-    const particleDeviceID = req.body.particleDeviceID
+    const serialNumber = req.body.particleDeviceID
     const phoneNumber = req.body.twilioNumber
     const clientID = req.body.clientID
+    const deviceType = req.body.deviceType
 
     if (paApiKeys.includes(braveAPIKey) && paPasswords.includes(password)) {
       try {
-        const results = await db.createLocationFromBrowserForm(locationID, displayName, deviceType, particleDeviceID, phoneNumber, clientID)
+        const results = await db.createLocationFromBrowserForm(locationID, displayName, serialNumber, phoneNumber, clientID, deviceType)
 
         if (results === null) {
           res.status(400).send({ message: 'Error in database insert' })

--- a/server/pa.js
+++ b/server/pa.js
@@ -48,6 +48,7 @@ const validateCreateSensorLocation = Validator.body([
   'particleDeviceID',
   'twilioNumber',
   'clientID',
+  'deviceType',
   'googleIdToken',
 ])
   .trim()
@@ -61,13 +62,14 @@ async function handleCreateSensorLocation(req, res) {
     const password = req.body.password
     const locationID = req.body.locationID
     const displayName = req.body.displayName
+    const deviceType = req.body.deviceType
     const particleDeviceID = req.body.particleDeviceID
     const phoneNumber = req.body.twilioNumber
     const clientID = req.body.clientID
 
     if (paApiKeys.includes(braveAPIKey) && paPasswords.includes(password)) {
       try {
-        const results = await db.createLocationFromBrowserForm(locationID, displayName, particleDeviceID, phoneNumber, clientID)
+        const results = await db.createLocationFromBrowserForm(locationID, displayName, deviceType, particleDeviceID, phoneNumber, clientID)
 
         if (results === null) {
           res.status(400).send({ message: 'Error in database insert' })

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -12,7 +12,7 @@
         "@sentry/node": "^6.2.5",
         "@sentry/tracing": "^6.2.5",
         "axios": "^1.7.4",
-        "brave-alert-lib": "https://github.com/bravetechnologycoop/brave-alert-lib#v15.0.3",
+        "brave-alert-lib": "https://github.com/bravetechnologycoop/brave-alert-lib#v15.0.4",
         "cookie-parser": "^1.4.5",
         "cors": "^2.8.5",
         "execution-time": "^1.4.1",
@@ -1712,8 +1712,8 @@
       }
     },
     "node_modules/brave-alert-lib": {
-      "version": "15.0.3",
-      "resolved": "git+ssh://git@github.com/bravetechnologycoop/brave-alert-lib.git#383c8db591eef4e48faa78bb1f38e6507f9f6cbf",
+      "version": "15.0.4",
+      "resolved": "git+ssh://git@github.com/bravetechnologycoop/brave-alert-lib.git#cbf910c13810dc8639ca03a1435f2ef93673dd38",
       "dependencies": {
         "@sentry/node": "^6.2.5",
         "@sentry/tracing": "^6.2.5",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -12,7 +12,7 @@
         "@sentry/node": "^6.2.5",
         "@sentry/tracing": "^6.2.5",
         "axios": "^1.7.4",
-        "brave-alert-lib": "github:bravetechnologycoop/brave-alert-lib#v14.0.2",
+        "brave-alert-lib": "https://github.com/bravetechnologycoop/brave-alert-lib#v15.0.3",
         "cookie-parser": "^1.4.5",
         "cors": "^2.8.5",
         "execution-time": "^1.4.1",
@@ -1712,14 +1712,14 @@
       }
     },
     "node_modules/brave-alert-lib": {
-      "version": "14.0.2",
-      "resolved": "git+ssh://git@github.com/bravetechnologycoop/brave-alert-lib.git#f58aaee3552999e56b9152cbef2792abfc977a51",
+      "version": "15.0.3",
+      "resolved": "git+ssh://git@github.com/bravetechnologycoop/brave-alert-lib.git#383c8db591eef4e48faa78bb1f38e6507f9f6cbf",
       "dependencies": {
         "@sentry/node": "^6.2.5",
         "@sentry/tracing": "^6.2.5",
         "chalk": "^4.1.0",
         "dotenv": "^7.0.0",
-        "express": "^4.19.2",
+        "express": "^4.21.0",
         "express-validator": "^6.10.0",
         "google-auth-library": "^9.2.0",
         "luxon": "^2.5.2",
@@ -2174,9 +2174,9 @@
       }
     },
     "node_modules/dayjs": {
-      "version": "1.11.10",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.10.tgz",
-      "integrity": "sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ=="
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
+      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg=="
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -3079,23 +3079,23 @@
       }
     },
     "node_modules/express": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.20.0.tgz",
-      "integrity": "sha512-pLdae7I6QqShF5PnNTCVn4hI91Dx0Grkn2+IAsMTgMIKuQVte2dN9PeGSSAME2FR8anOhVA62QDIUaWVfEXVLw==",
+      "version": "4.21.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.1.tgz",
+      "integrity": "sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
         "body-parser": "1.20.3",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.6.0",
+        "cookie": "0.7.1",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
         "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "etag": "~1.8.1",
-        "finalhandler": "1.2.0",
+        "finalhandler": "1.3.1",
         "fresh": "0.5.2",
         "http-errors": "2.0.0",
         "merge-descriptors": "1.0.3",
@@ -3104,11 +3104,11 @@
         "parseurl": "~1.3.3",
         "path-to-regexp": "0.1.10",
         "proxy-addr": "~2.0.7",
-        "qs": "6.11.0",
+        "qs": "6.13.0",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
         "send": "0.19.0",
-        "serve-static": "1.16.0",
+        "serve-static": "1.16.2",
         "setprototypeof": "1.2.0",
         "statuses": "2.0.1",
         "type-is": "~1.6.18",
@@ -3163,9 +3163,9 @@
       }
     },
     "node_modules/express/node_modules/cookie": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
       "engines": {
         "node": ">= 0.6"
       }
@@ -3190,20 +3190,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
-    },
-    "node_modules/express/node_modules/qs": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
-      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
-      "dependencies": {
-        "side-channel": "^1.0.4"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
     },
     "node_modules/extend": {
       "version": "3.0.2",
@@ -3272,12 +3258,12 @@
       }
     },
     "node_modules/finalhandler": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
-      "integrity": "sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
+      "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
       "dependencies": {
         "debug": "2.6.9",
-        "encodeurl": "~1.0.2",
+        "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
@@ -3294,6 +3280,14 @@
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "dependencies": {
         "ms": "2.0.0"
+      }
+    },
+    "node_modules/finalhandler/node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/finalhandler/node_modules/ms": {
@@ -3535,23 +3529,24 @@
       }
     },
     "node_modules/gaxios": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.1.1.tgz",
-      "integrity": "sha512-bw8smrX+XlAoo9o1JAksBwX+hi/RG15J+NTSxmNPIclKC3ZVK6C2afwY8OSdRvOK0+ZLecUJYtj2MmjOt3Dm0w==",
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
+      "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
       "dependencies": {
         "extend": "^3.0.2",
         "https-proxy-agent": "^7.0.1",
         "is-stream": "^2.0.0",
-        "node-fetch": "^2.6.9"
+        "node-fetch": "^2.6.9",
+        "uuid": "^9.0.1"
       },
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/gaxios/node_modules/agent-base": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
-      "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
+      "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
       "dependencies": {
         "debug": "^4.3.4"
       },
@@ -3560,15 +3555,27 @@
       }
     },
     "node_modules/gaxios/node_modules/https-proxy-agent": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.2.tgz",
-      "integrity": "sha512-NmLNjm6ucYwtcUmL7JQC1ZQ57LmHP4lT15FQ8D61nak1rO6DH+fz5qNK2Ap5UN4ZapYICE3/0KodcLYSPsPbaA==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.5.tgz",
+      "integrity": "sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==",
       "dependencies": {
         "agent-base": "^7.0.2",
         "debug": "4"
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/gaxios/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/gcp-metadata": {
@@ -3724,14 +3731,14 @@
       }
     },
     "node_modules/google-auth-library": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.3.0.tgz",
-      "integrity": "sha512-W0F5CB7rAi9l+7/IVeKu26+KdzY6tCwXKAlLsZrleU/Q61XM16uonrDCQNld3Douv/5CH+YoULqNEVVkdmi5Qw==",
+      "version": "9.14.2",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.14.2.tgz",
+      "integrity": "sha512-R+FRIfk1GBo3RdlRYWPdwk8nmtVUOn6+BkDomAC46KoU8kzXzE1HLmOasSCbWUByMMAGkknVF0G5kQ69Vj7dlA==",
       "dependencies": {
         "base64-js": "^1.3.0",
         "ecdsa-sig-formatter": "^1.0.11",
-        "gaxios": "^6.0.0",
-        "gcp-metadata": "^6.0.0",
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
         "gtoken": "^7.0.0",
         "jws": "^4.0.0"
       },
@@ -3766,9 +3773,9 @@
       }
     },
     "node_modules/gtoken": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.0.1.tgz",
-      "integrity": "sha512-KcFVtoP1CVFtQu0aSk3AyAt2og66PFhZAlkUOuWKwzMLoulHXG5W5wE5xAnHb+yl3/wEFoqGW7/cDGMU8igDZQ==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
+      "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
       "dependencies": {
         "gaxios": "^6.0.0",
         "jws": "^4.0.0"
@@ -6683,58 +6690,25 @@
       }
     },
     "node_modules/serve-static": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.0.tgz",
-      "integrity": "sha512-pDLK8zwl2eKaYrs8mrPZBJua4hMplRWJ1tIFksVC3FtBEBnl8dxgeHtsaMS8DhS9i4fLObaon6ABoc4/hQGdPA==",
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
+      "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
       "dependencies": {
-        "encodeurl": "~1.0.2",
+        "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "parseurl": "~1.3.3",
-        "send": "0.18.0"
+        "send": "0.19.0"
       },
       "engines": {
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/serve-static/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/serve-static/node_modules/debug/node_modules/ms": {
+    "node_modules/serve-static/node_modules/encodeurl": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
-    },
-    "node_modules/serve-static/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-    },
-    "node_modules/serve-static/node_modules/send": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
-      "integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
-      "dependencies": {
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "fresh": "0.5.2",
-        "http-errors": "2.0.0",
-        "mime": "1.6.0",
-        "ms": "2.1.3",
-        "on-finished": "2.4.1",
-        "range-parser": "~1.2.1",
-        "statuses": "2.0.1"
-      },
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
       "engines": {
-        "node": ">= 0.8.0"
+        "node": ">= 0.8"
       }
     },
     "node_modules/set-blocking": {
@@ -7300,9 +7274,9 @@
       "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="
     },
     "node_modules/twilio": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/twilio/-/twilio-4.20.0.tgz",
-      "integrity": "sha512-Dl49awVTgv9LOLrmXi7elKa2mb69rtkwJHlKNbIR9HjXN7q66gEEaiZsE6gdr+Wfk/zInOvPDVBCdQM+SYXqkA==",
+      "version": "4.23.0",
+      "resolved": "https://registry.npmjs.org/twilio/-/twilio-4.23.0.tgz",
+      "integrity": "sha512-LdNBQfOe0dY2oJH2sAsrxazpgfFQo5yXGxe96QA8UWB5uu+433PrUbkv8gQ5RmrRCqUTPQ0aOrIyAdBr1aB03Q==",
       "dependencies": {
         "axios": "^1.6.0",
         "dayjs": "^1.11.9",

--- a/server/package.json
+++ b/server/package.json
@@ -20,7 +20,7 @@
     "@sentry/node": "^6.2.5",
     "@sentry/tracing": "^6.2.5",
     "axios": "^1.7.4",
-    "brave-alert-lib": "https://github.com/bravetechnologycoop/brave-alert-lib#v15.0.3",
+    "brave-alert-lib": "https://github.com/bravetechnologycoop/brave-alert-lib#v15.0.4",
     "cookie-parser": "^1.4.5",
     "cors": "^2.8.5",
     "execution-time": "^1.4.1",

--- a/server/package.json
+++ b/server/package.json
@@ -20,7 +20,7 @@
     "@sentry/node": "^6.2.5",
     "@sentry/tracing": "^6.2.5",
     "axios": "^1.7.4",
-    "brave-alert-lib": "github:bravetechnologycoop/brave-alert-lib#v14.0.2",
+    "brave-alert-lib": "https://github.com/bravetechnologycoop/brave-alert-lib#v15.0.3",
     "cookie-parser": "^1.4.5",
     "cors": "^2.8.5",
     "execution-time": "^1.4.1",

--- a/server/test/integration/dashboardTest/submitEditLocationTest.js
+++ b/server/test/integration/dashboardTest/submitEditLocationTest.js
@@ -25,12 +25,14 @@ describe('dashboard.js integration tests: submitEditLocation', () => {
     sandbox.spy(db, 'updateLocation')
 
     this.testLocationIdForEdit = 'test1'
+    this.testLocationDeviceType = 'DEVICE_SENSOR_SINGLESTALL'
 
     await db.clearTables()
 
     this.client = await factories.clientDBFactory(db)
     this.test1 = await factories.locationDBFactory(db, {
       locationid: this.testLocationIdForEdit,
+      deviceType: this.testLocationDeviceType,
       clientId: this.client.id,
     })
 
@@ -50,14 +52,23 @@ describe('dashboard.js integration tests: submitEditLocation', () => {
         password: helpers.getEnvVar('PASSWORD'),
       })
 
+      this.displayName = 'New Name'
+      this.serialNumber = 'new_radar_core'
+      this.phoneNumber = '+11112223456'
+      this.isDisplayed = true
+      this.isSendingAlerts = true
+      this.isSendingVitals = false
+      this.clientId = this.client.id
+      this.deviceType = 'DEVICE_SENSOR_SINGLESTALL'
       this.goodRequest = {
-        displayName: 'New Name',
-        serialNumber: 'new_radar_core',
-        phoneNumber: '+11112223456',
-        isDisplayed: 'true',
-        isSendingAlerts: 'true',
-        isSendingVitals: 'false',
-        clientId: this.client.id,
+        displayName: this.displayName,
+        serialNumber: this.serialNumber,
+        phoneNumber: this.phoneNumber,
+        isDisplayed: this.isDisplayed,
+        isSendingAlerts: this.isSendingAlerts,
+        isSendingVitals: this.isSendingVitals,
+        clientId: this.clientId,
+        deviceType: this.deviceType,
       }
 
       this.response = await this.agent.post(`/locations/${this.test1.id}`).send(this.goodRequest)
@@ -70,13 +81,25 @@ describe('dashboard.js integration tests: submitEditLocation', () => {
     it('should update the location in the database', async () => {
       const updatedLocation = await db.getLocationWithLocationid(this.testLocationIdForEdit)
 
-      expect(updatedLocation.displayName).to.equal(this.goodRequest.displayName)
-      expect(updatedLocation.serialNumber).to.equal(this.goodRequest.serialNumber)
-      expect(updatedLocation.phoneNumber).to.equal(this.goodRequest.phoneNumber)
-      expect(updatedLocation.isDisplayed).to.be.true
-      expect(updatedLocation.isSendingAlerts).to.be.true
-      expect(updatedLocation.isSendingVitals).to.be.false
-      expect(updatedLocation.client.id).to.equal(this.goodRequest.clientId)
+      expect({
+        displayName: updatedLocation.displayName,
+        serialNumber: updatedLocation.serialNumber,
+        phoneNumber: updatedLocation.phoneNumber,
+        isDisplayed: updatedLocation.isDisplayed,
+        isSendingAlerts: updatedLocation.isSendingAlerts,
+        isSendingVitals: updatedLocation.isSendingVitals,
+        clientId: updatedLocation.client.id,
+        deviceType: updatedLocation.deviceType,
+      }).to.eql({
+        displayName: this.displayName,
+        serialNumber: this.serialNumber,
+        phoneNumber: this.phoneNumber,
+        isDisplayed: this.isDisplayed,
+        isSendingAlerts: this.isSendingAlerts,
+        isSendingVitals: this.isSendingVitals,
+        clientId: this.client.id,
+        deviceType: this.deviceType,
+      })
     })
   })
 
@@ -87,14 +110,23 @@ describe('dashboard.js integration tests: submitEditLocation', () => {
         password: helpers.getEnvVar('PASSWORD'),
       })
 
+      this.displayName = ' New Name '
+      this.serialNumber = '   new_radar_core '
+      this.phoneNumber = '    +11112223456    '
+      this.isDisplayed = '    true     '
+      this.isSendingAlerts = '    true     '
+      this.isSendingVitals = '    true     '
+      this.clientId = `   ${this.client.id}   `
+      this.deviceType = '   DEVICE_SENSOR_SINGLESTALL   '
       this.goodRequest = {
-        displayName: ' New Name ',
-        serialNumber: '   new_radar_core ',
-        phoneNumber: '    +11112223456    ',
-        isDisplayed: '    true     ',
-        isSendingAlerts: '    true     ',
-        isSendingVitals: '    false     ',
-        clientId: `   ${this.client.id}   `,
+        displayName: this.displayName,
+        serialNumber: this.serialNumber,
+        phoneNumber: this.phoneNumber,
+        isDisplayed: this.isDisplayed,
+        isSendingAlerts: this.isSendingAlerts,
+        isSendingVitals: this.isSendingVitals,
+        clientId: this.clientId,
+        deviceType: this.deviceType,
       }
 
       this.response = await this.agent.post(`/locations/${this.test1.id}`).send(this.goodRequest)
@@ -107,13 +139,25 @@ describe('dashboard.js integration tests: submitEditLocation', () => {
     it('should update the location in the database', async () => {
       const updatedLocation = await db.getLocationWithLocationid(this.testLocationIdForEdit)
 
-      expect(updatedLocation.displayName).to.equal(this.goodRequest.displayName.trim())
-      expect(updatedLocation.serialNumber).to.equal(this.goodRequest.serialNumber.trim())
-      expect(updatedLocation.phoneNumber).to.equal(this.goodRequest.phoneNumber.trim())
-      expect(updatedLocation.isDisplayed).to.be.true
-      expect(updatedLocation.isSendingAlerts).to.be.true
-      expect(updatedLocation.isSendingVitals).to.be.false
-      expect(updatedLocation.client.id).to.equal(this.goodRequest.clientId.trim())
+      expect({
+        displayName: updatedLocation.displayName,
+        serialNumber: updatedLocation.serialNumber,
+        phoneNumber: updatedLocation.phoneNumber,
+        isDisplayed: updatedLocation.isDisplayed,
+        isSendingAlerts: updatedLocation.isSendingAlerts,
+        isSendingVitals: updatedLocation.isSendingVitals,
+        clientId: updatedLocation.client.id,
+        deviceType: updatedLocation.deviceType,
+      }).to.eql({
+        displayName: this.displayName.trim(),
+        serialNumber: this.serialNumber.trim(),
+        phoneNumber: this.phoneNumber.trim(),
+        isDisplayed: this.isDisplayed.trim() === 'true',
+        isSendingAlerts: this.isSendingAlerts.trim() === 'true',
+        isSendingVitals: this.isSendingVitals.trim() === 'true',
+        clientId: this.clientId.trim(),
+        deviceType: this.deviceType.trim(),
+      })
     })
   })
 
@@ -124,14 +168,23 @@ describe('dashboard.js integration tests: submitEditLocation', () => {
         password: helpers.getEnvVar('PASSWORD'),
       })
 
+      this.displayName = 'New Name'
+      this.serialNumber = 'new_radar_core'
+      this.phoneNumber = '+11112223456'
+      this.isDisplayed = false
+      this.isSendingAlerts = false
+      this.isSendingVitals = true
+      this.clientId = this.client.id
+      this.deviceType = 'DEVICE_SENSOR_SINGLESTALL'
       this.goodRequest = {
-        displayName: 'New Name',
-        serialNumber: 'new_radar_core',
-        phoneNumber: '+11112223456',
-        isDisplayed: 'false',
-        isSendingAlerts: 'false',
-        isSendingVitals: 'true',
-        clientId: this.client.id,
+        displayName: this.displayName,
+        serialNumber: this.serialNumber,
+        phoneNumber: this.phoneNumber,
+        isDisplayed: this.isDisplayed,
+        isSendingAlerts: this.isSendingAlerts,
+        isSendingVitals: this.isSendingVitals,
+        clientId: this.clientId,
+        deviceType: this.deviceType,
       }
 
       this.response = await this.agent.post(`/locations/${this.test1.id}`).send(this.goodRequest)
@@ -144,13 +197,83 @@ describe('dashboard.js integration tests: submitEditLocation', () => {
     it('should update the location in the database', async () => {
       const updatedLocation = await db.getLocationWithLocationid(this.testLocationIdForEdit)
 
-      expect(updatedLocation.displayName).to.equal(this.goodRequest.displayName)
-      expect(updatedLocation.serialNumber).to.equal(this.goodRequest.serialNumber)
-      expect(updatedLocation.phoneNumber).to.equal(this.goodRequest.phoneNumber)
-      expect(updatedLocation.isDisplayed).to.be.false
-      expect(updatedLocation.isSendingAlerts).to.be.false
-      expect(updatedLocation.isSendingVitals).to.be.true
-      expect(updatedLocation.client.id).to.equal(this.goodRequest.clientId)
+      expect({
+        displayName: updatedLocation.displayName,
+        serialNumber: updatedLocation.serialNumber,
+        phoneNumber: updatedLocation.phoneNumber,
+        isDisplayed: updatedLocation.isDisplayed,
+        isSendingAlerts: updatedLocation.isSendingAlerts,
+        isSendingVitals: updatedLocation.isSendingVitals,
+        clientId: updatedLocation.client.id,
+        deviceType: updatedLocation.deviceType,
+      }).to.eql({
+        displayName: this.displayName,
+        serialNumber: this.serialNumber,
+        phoneNumber: this.phoneNumber,
+        isDisplayed: this.isDisplayed,
+        isSendingAlerts: this.isSendingAlerts,
+        isSendingVitals: this.isSendingVitals,
+        clientId: this.clientId,
+        deviceType: this.deviceType,
+      })
+    })
+  })
+
+  describe('for a request that changes device type (singlestall to multistall)', () => {
+    beforeEach(async () => {
+      await this.agent.post('/login').send({
+        username: helpers.getEnvVar('WEB_USERNAME'),
+        password: helpers.getEnvVar('PASSWORD'),
+      })
+
+      this.displayName = 'New Name'
+      this.serialNumber = 'new_radar_core'
+      this.phoneNumber = '+11112223456'
+      this.isDisplayed = true
+      this.isSendingAlerts = true
+      this.isSendingVitals = false
+      this.clientId = this.client.id
+      this.deviceType = 'DEVICE_SENSOR_MULTISTALL'
+      this.goodRequest = {
+        displayName: this.displayName,
+        serialNumber: this.serialNumber,
+        phoneNumber: this.phoneNumber,
+        isDisplayed: this.isDisplayed,
+        isSendingAlerts: this.isSendingAlerts,
+        isSendingVitals: this.isSendingVitals,
+        clientId: this.clientId,
+        deviceType: this.deviceType,
+      }
+
+      this.response = await this.agent.post(`/locations/${this.test1.id}`).send(this.goodRequest)
+    })
+
+    it('should return 200', () => {
+      expect(this.response).to.have.status(200)
+    })
+
+    it('should update the location in the database', async () => {
+      const updatedLocation = await db.getLocationWithLocationid(this.testLocationIdForEdit)
+
+      expect({
+        displayName: updatedLocation.displayName,
+        serialNumber: updatedLocation.serialNumber,
+        phoneNumber: updatedLocation.phoneNumber,
+        isDisplayed: updatedLocation.isDisplayed,
+        isSendingAlerts: updatedLocation.isSendingAlerts,
+        isSendingVitals: updatedLocation.isSendingVitals,
+        clientId: updatedLocation.client.id,
+        deviceType: updatedLocation.deviceType,
+      }).to.eql({
+        displayName: this.displayName,
+        serialNumber: this.serialNumber,
+        phoneNumber: this.phoneNumber,
+        isDisplayed: this.isDisplayed,
+        isSendingAlerts: this.isSendingAlerts,
+        isSendingVitals: this.isSendingVitals,
+        clientId: this.clientId,
+        deviceType: this.deviceType,
+      })
     })
   })
 
@@ -170,6 +293,7 @@ describe('dashboard.js integration tests: submitEditLocation', () => {
         isSendingAlerts: 'true',
         isSendingVitals: 'false',
         clientId: this.clientId,
+        deviceType: 'DEVICE_SENSOR_SINGLESTALL',
       }
 
       this.response = await this.agent.post(`/locations/${this.test1.id}`).send(this.goodRequest)
@@ -206,6 +330,7 @@ describe('dashboard.js integration tests: submitEditLocation', () => {
         isSendingAlerts: '',
         isSendingVitals: '',
         clientId: '',
+        deviceType: '',
       }
 
       this.response = await this.agent.post(`/locations/${this.test1.id}`).send(badRequest)
@@ -221,7 +346,7 @@ describe('dashboard.js integration tests: submitEditLocation', () => {
 
     it('should log the error', () => {
       expect(helpers.log).to.have.been.calledWith(
-        `Bad request to /locations/${this.test1.id}: displayName (Invalid value),serialNumber (Invalid value),phoneNumber (Invalid value),isDisplayed (Invalid value),isSendingAlerts (Invalid value),isSendingVitals (Invalid value),clientId (Invalid value)`,
+        `Bad request to /locations/${this.test1.id}: displayName (Invalid value),serialNumber (Invalid value),phoneNumber (Invalid value),isDisplayed (Invalid value),isSendingAlerts (Invalid value),isSendingVitals (Invalid value),clientId (Invalid value),deviceType (Invalid value)`,
       )
     })
   })
@@ -253,7 +378,7 @@ describe('dashboard.js integration tests: submitEditLocation', () => {
 
     it('should log the error', () => {
       expect(helpers.log).to.have.been.calledWith(
-        `Bad request to /locations/${this.test1.id}: displayName (Invalid value),serialNumber (Invalid value),phoneNumber (Invalid value),isDisplayed (Invalid value),isSendingAlerts (Invalid value),isSendingVitals (Invalid value),clientId (Invalid value)`,
+        `Bad request to /locations/${this.test1.id}: displayName (Invalid value),serialNumber (Invalid value),phoneNumber (Invalid value),isDisplayed (Invalid value),isSendingAlerts (Invalid value),isSendingVitals (Invalid value),clientId (Invalid value),deviceType (Invalid value)`,
       )
     })
   })

--- a/server/test/integration/dashboardTest/submitEditLocationTest.js
+++ b/server/test/integration/dashboardTest/submitEditLocationTest.js
@@ -25,7 +25,7 @@ describe('dashboard.js integration tests: submitEditLocation', () => {
     sandbox.spy(db, 'updateLocation')
 
     this.testLocationIdForEdit = 'test1'
-    this.testLocationDeviceType = 'DEVICE_SENSOR_SINGLESTALL'
+    this.testLocationDeviceType = 'SENSOR_SINGLESTALL'
 
     await db.clearTables()
 
@@ -59,7 +59,7 @@ describe('dashboard.js integration tests: submitEditLocation', () => {
       this.isSendingAlerts = true
       this.isSendingVitals = false
       this.clientId = this.client.id
-      this.deviceType = 'DEVICE_SENSOR_SINGLESTALL'
+      this.deviceType = 'SENSOR_SINGLESTALL'
       this.goodRequest = {
         displayName: this.displayName,
         serialNumber: this.serialNumber,
@@ -117,7 +117,7 @@ describe('dashboard.js integration tests: submitEditLocation', () => {
       this.isSendingAlerts = '    true     '
       this.isSendingVitals = '    true     '
       this.clientId = `   ${this.client.id}   `
-      this.deviceType = '   DEVICE_SENSOR_SINGLESTALL   '
+      this.deviceType = '   SENSOR_SINGLESTALL   '
       this.goodRequest = {
         displayName: this.displayName,
         serialNumber: this.serialNumber,
@@ -175,7 +175,7 @@ describe('dashboard.js integration tests: submitEditLocation', () => {
       this.isSendingAlerts = false
       this.isSendingVitals = true
       this.clientId = this.client.id
-      this.deviceType = 'DEVICE_SENSOR_SINGLESTALL'
+      this.deviceType = 'SENSOR_SINGLESTALL'
       this.goodRequest = {
         displayName: this.displayName,
         serialNumber: this.serialNumber,
@@ -233,7 +233,7 @@ describe('dashboard.js integration tests: submitEditLocation', () => {
       this.isSendingAlerts = true
       this.isSendingVitals = false
       this.clientId = this.client.id
-      this.deviceType = 'DEVICE_SENSOR_MULTISTALL'
+      this.deviceType = 'SENSOR_MULTISTALL'
       this.goodRequest = {
         displayName: this.displayName,
         serialNumber: this.serialNumber,
@@ -293,7 +293,7 @@ describe('dashboard.js integration tests: submitEditLocation', () => {
         isSendingAlerts: 'true',
         isSendingVitals: 'false',
         clientId: this.clientId,
-        deviceType: 'DEVICE_SENSOR_SINGLESTALL',
+        deviceType: 'SENSOR_SINGLESTALL',
       }
 
       this.response = await this.agent.post(`/locations/${this.test1.id}`).send(this.goodRequest)

--- a/server/test/integration/dashboardTest/submitNewLocationTest.js
+++ b/server/test/integration/dashboardTest/submitNewLocationTest.js
@@ -47,12 +47,14 @@ describe('dashboard.js integration tests: submitNewLocation', () => {
       this.displayName = 'locationName'
       this.serialNumber = 'radar_coreID'
       this.phoneNumber = '+15005550006'
+      this.deviceType = 'DEVICE_SENSOR_SINGLESTALL'
       const goodRequest = {
         locationid: this.locationid,
         displayName: this.displayName,
         serialNumber: this.serialNumber,
         phoneNumber: this.phoneNumber,
         clientId: this.client.id,
+        deviceType: this.deviceType,
       }
 
       this.response = await this.agent.post('/locations').send(goodRequest)
@@ -71,12 +73,63 @@ describe('dashboard.js integration tests: submitNewLocation', () => {
         serialNumber: newLocation.serialNumber,
         phoneNumber: newLocation.phoneNumber,
         clientId: newLocation.client.id,
+        deviceType: newLocation.deviceType,
       }).to.eql({
         locationid: this.locationid,
         displayName: this.displayName,
         serialNumber: this.serialNumber,
         phoneNumber: this.phoneNumber,
         clientId: this.client.id,
+        deviceType: this.deviceType,
+      })
+    })
+  })
+
+  describe('for a multistall location with all valid non-empty fields', () => {
+    beforeEach(async () => {
+      await this.agent.post('/login').send({
+        username: helpers.getEnvVar('WEB_USERNAME'),
+        password: helpers.getEnvVar('PASSWORD'),
+      })
+
+      this.locationid = 'unusedID'
+      this.displayName = 'locationName'
+      this.serialNumber = 'radar_coreID'
+      this.phoneNumber = '+15005550006'
+      this.deviceType = 'DEVICE_SENSOR_MULTISTALL'
+      const goodRequest = {
+        locationid: this.locationid,
+        displayName: this.displayName,
+        serialNumber: this.serialNumber,
+        phoneNumber: this.phoneNumber,
+        clientId: this.client.id,
+        deviceType: this.deviceType,
+      }
+
+      this.response = await this.agent.post('/locations').send(goodRequest)
+    })
+
+    it('should return 200', () => {
+      expect(this.response).to.have.status(200)
+    })
+
+    it('should create a mustistall location in the database with the given values', async () => {
+      const newLocation = await db.getLocationWithLocationid(this.locationid)
+
+      expect({
+        locationid: newLocation.locationid,
+        displayName: newLocation.displayName,
+        serialNumber: newLocation.serialNumber,
+        phoneNumber: newLocation.phoneNumber,
+        clientId: newLocation.client.id,
+        deviceType: newLocation.deviceType,
+      }).to.eql({
+        locationid: this.locationid,
+        displayName: this.displayName,
+        serialNumber: this.serialNumber,
+        phoneNumber: this.phoneNumber,
+        clientId: this.client.id,
+        deviceType: this.deviceType,
       })
     })
   })
@@ -92,12 +145,14 @@ describe('dashboard.js integration tests: submitNewLocation', () => {
       this.displayName = '  locationName  '
       this.serialNumber = '    radar_coreID    '
       this.phoneNumber = '   +15005550006    '
+      this.deviceType = '  DEVICE_SENSOR_SINGLESTALL  '
       const goodRequest = {
         locationid: this.locationid,
         displayName: this.displayName,
         serialNumber: this.serialNumber,
         phoneNumber: this.phoneNumber,
         clientId: `  ${this.client.id}   `,
+        deviceType: this.deviceType,
       }
 
       this.response = await this.agent.post('/locations').send(goodRequest)
@@ -116,12 +171,14 @@ describe('dashboard.js integration tests: submitNewLocation', () => {
         serialNumber: newLocation.serialNumber,
         phoneNumber: newLocation.phoneNumber,
         clientId: newLocation.client.id,
+        deviceType: newLocation.deviceType,
       }).to.eql({
         locationid: this.locationid.trim(),
         displayName: this.displayName.trim(),
         serialNumber: this.serialNumber.trim(),
         phoneNumber: this.phoneNumber.trim(),
         clientId: this.client.id.trim(),
+        deviceType: this.deviceType.trim(),
       })
     })
   })
@@ -142,6 +199,7 @@ describe('dashboard.js integration tests: submitNewLocation', () => {
         serialNumber: 'radar_coreID',
         phoneNumber: '+15005550006',
         clientId: this.clientId,
+        deviceType: 'DEVICE_SENSOR_SINGLESTALL',
       }
 
       this.response = await this.agent.post('/locations').send(goodRequest)
@@ -170,6 +228,7 @@ describe('dashboard.js integration tests: submitNewLocation', () => {
         serialNumber: 'radar_coreID',
         phoneNumber: '+15005550006',
         clientId: '91ddc8f7-c2e7-490e-bfe9-3d2880a76108',
+        deviceType: 'DEVICE_SENSOR_SINGLESTALL',
       }
 
       this.response = await chai.request(server).post('/locations').send(goodRequest)
@@ -203,6 +262,7 @@ describe('dashboard.js integration tests: submitNewLocation', () => {
         serialNumber: '',
         phoneNumber: '',
         clientId: '',
+        deviceType: '',
       }
 
       this.response = await this.agent.post('/locations').send(badRequest)
@@ -218,7 +278,7 @@ describe('dashboard.js integration tests: submitNewLocation', () => {
 
     it('should log the error', () => {
       expect(helpers.log).to.have.been.calledWith(
-        `Bad request to /locations: locationid (Invalid value),displayName (Invalid value),serialNumber (Invalid value),phoneNumber (Invalid value),clientId (Invalid value)`,
+        `Bad request to /locations: locationid (Invalid value),displayName (Invalid value),deviceType (Invalid value),serialNumber (Invalid value),phoneNumber (Invalid value),clientId (Invalid value)`,
       )
     })
   })
@@ -245,7 +305,7 @@ describe('dashboard.js integration tests: submitNewLocation', () => {
 
     it('should log the error', () => {
       expect(helpers.log).to.have.been.calledWith(
-        `Bad request to /locations: locationid (Invalid value),displayName (Invalid value),serialNumber (Invalid value),phoneNumber (Invalid value),clientId (Invalid value)`,
+        `Bad request to /locations: locationid (Invalid value),displayName (Invalid value),deviceType (Invalid value),serialNumber (Invalid value),phoneNumber (Invalid value),clientId (Invalid value)`,
       )
     })
   })
@@ -271,6 +331,7 @@ describe('dashboard.js integration tests: submitNewLocation', () => {
         serialNumber: 'radar_coreID',
         phoneNumber: '+15005550006',
         clientId: this.client.id,
+        deviceType: 'DEVICE_SENSOR_SINGLESTALL',
       }
 
       this.response = await this.agent.post('/locations').send(duplicateLocationRequest)

--- a/server/test/integration/dashboardTest/submitNewLocationTest.js
+++ b/server/test/integration/dashboardTest/submitNewLocationTest.js
@@ -47,7 +47,7 @@ describe('dashboard.js integration tests: submitNewLocation', () => {
       this.displayName = 'locationName'
       this.serialNumber = 'radar_coreID'
       this.phoneNumber = '+15005550006'
-      this.deviceType = 'DEVICE_SENSOR_SINGLESTALL'
+      this.deviceType = 'SENSOR_SINGLESTALL'
       const goodRequest = {
         locationid: this.locationid,
         displayName: this.displayName,
@@ -96,7 +96,7 @@ describe('dashboard.js integration tests: submitNewLocation', () => {
       this.displayName = 'locationName'
       this.serialNumber = 'radar_coreID'
       this.phoneNumber = '+15005550006'
-      this.deviceType = 'DEVICE_SENSOR_MULTISTALL'
+      this.deviceType = 'SENSOR_MULTISTALL'
       const goodRequest = {
         locationid: this.locationid,
         displayName: this.displayName,
@@ -145,7 +145,7 @@ describe('dashboard.js integration tests: submitNewLocation', () => {
       this.displayName = '  locationName  '
       this.serialNumber = '    radar_coreID    '
       this.phoneNumber = '   +15005550006    '
-      this.deviceType = '  DEVICE_SENSOR_SINGLESTALL  '
+      this.deviceType = '  SENSOR_SINGLESTALL  '
       const goodRequest = {
         locationid: this.locationid,
         displayName: this.displayName,
@@ -199,7 +199,7 @@ describe('dashboard.js integration tests: submitNewLocation', () => {
         serialNumber: 'radar_coreID',
         phoneNumber: '+15005550006',
         clientId: this.clientId,
-        deviceType: 'DEVICE_SENSOR_SINGLESTALL',
+        deviceType: 'SENSOR_SINGLESTALL',
       }
 
       this.response = await this.agent.post('/locations').send(goodRequest)
@@ -228,7 +228,7 @@ describe('dashboard.js integration tests: submitNewLocation', () => {
         serialNumber: 'radar_coreID',
         phoneNumber: '+15005550006',
         clientId: '91ddc8f7-c2e7-490e-bfe9-3d2880a76108',
-        deviceType: 'DEVICE_SENSOR_SINGLESTALL',
+        deviceType: 'SENSOR_SINGLESTALL',
       }
 
       this.response = await chai.request(server).post('/locations').send(goodRequest)
@@ -331,7 +331,7 @@ describe('dashboard.js integration tests: submitNewLocation', () => {
         serialNumber: 'radar_coreID',
         phoneNumber: '+15005550006',
         clientId: this.client.id,
-        deviceType: 'DEVICE_SENSOR_SINGLESTALL',
+        deviceType: 'SENSOR_SINGLESTALL',
       }
 
       this.response = await this.agent.post('/locations').send(duplicateLocationRequest)

--- a/server/test/integration/dashboardTest/submitNewLocationTest.js
+++ b/server/test/integration/dashboardTest/submitNewLocationTest.js
@@ -278,7 +278,7 @@ describe('dashboard.js integration tests: submitNewLocation', () => {
 
     it('should log the error', () => {
       expect(helpers.log).to.have.been.calledWith(
-        `Bad request to /locations: locationid (Invalid value),displayName (Invalid value),deviceType (Invalid value),serialNumber (Invalid value),phoneNumber (Invalid value),clientId (Invalid value)`,
+        `Bad request to /locations: locationid (Invalid value),displayName (Invalid value),serialNumber (Invalid value),phoneNumber (Invalid value),clientId (Invalid value),deviceType (Invalid value)`,
       )
     })
   })
@@ -305,7 +305,7 @@ describe('dashboard.js integration tests: submitNewLocation', () => {
 
     it('should log the error', () => {
       expect(helpers.log).to.have.been.calledWith(
-        `Bad request to /locations: locationid (Invalid value),displayName (Invalid value),deviceType (Invalid value),serialNumber (Invalid value),phoneNumber (Invalid value),clientId (Invalid value)`,
+        `Bad request to /locations: locationid (Invalid value),displayName (Invalid value),serialNumber (Invalid value),phoneNumber (Invalid value),clientId (Invalid value),deviceType (Invalid value)`,
       )
     })
   })

--- a/server/test/integration/dbTest/getActiveSensorClientsTest.js
+++ b/server/test/integration/dbTest/getActiveSensorClientsTest.js
@@ -22,7 +22,7 @@ async function dbInsertActiveClients() {
 
     // create a singlestall location for this client that is sending alerts and vitals
     await factories.locationDBFactory(db, {
-      deviceType: DEVICE_TYPE.DEVICE_SENSOR_SINGLESTALL,
+      deviceType: DEVICE_TYPE.SENSOR_SINGLESTALL,
       locationid: `active-client-singlestall-location-${index}`,
       displayName: `Active Client Singlestall Location ${index}`,
       clientId: client.id,
@@ -32,7 +32,7 @@ async function dbInsertActiveClients() {
 
     // create a multistall location for this client that is sending alerts and vitals
     await factories.locationDBFactory(db, {
-      deviceType: DEVICE_TYPE.DEVICE_SENSOR_MULTISTALL,
+      deviceType: DEVICE_TYPE.SENSOR_MULTISTALL,
       locationid: `active-client-multistall-location-${index}`,
       displayName: `Active Client Multistall Location ${index}`,
       clientId: client.id,
@@ -187,7 +187,7 @@ async function dbInsertInactiveClients() {
     if (options.clientHasLocation) {
       // create a singlestall location for this client that is sending alerts and vitals
       await factories.locationDBFactory(db, {
-        deviceType: DEVICE_TYPE.DEVICE_SENSOR_SINGLESTALL,
+        deviceType: DEVICE_TYPE.SENSOR_SINGLESTALL,
         locationid: `inactive-client-singlestall-location-${index}`,
         displayName: `Inactive Client Singlestall Location ${index}`,
         clientId: client.id,
@@ -197,7 +197,7 @@ async function dbInsertInactiveClients() {
 
       // create a multistall location for this client that is sending alerts and vitals
       await factories.locationDBFactory(db, {
-        deviceType: DEVICE_TYPE.DEVICE_SENSOR_MULTISTALL,
+        deviceType: DEVICE_TYPE.SENSOR_MULTISTALL,
         locationid: `inactive-client-mutlistall-location-${index}`,
         displayName: `Inactive Client Multistall Location ${index}`,
         clientId: client.id,

--- a/server/test/integration/dbTest/getActiveSensorClientsTest.js
+++ b/server/test/integration/dbTest/getActiveSensorClientsTest.js
@@ -3,7 +3,7 @@ const { expect } = require('chai')
 const { afterEach, beforeEach, describe, it } = require('mocha')
 
 // In-house dependencies
-const { factories } = require('brave-alert-lib')
+const { factories, DEVICE_TYPE } = require('brave-alert-lib')
 const db = require('../../../db/db')
 
 // arbitrary number of active clients to generate
@@ -20,10 +20,21 @@ async function dbInsertActiveClients() {
       isSendingVitals: true,
     })
 
-    // create a location for this client that is sending alerts and vitals
+    // create a singlestall location for this client that is sending alerts and vitals
     await factories.locationDBFactory(db, {
-      locationid: `active-client-location-${index}`,
-      displayName: `Active Client Location ${index}`,
+      deviceType: DEVICE_TYPE.DEVICE_SENSOR_SINGLESTALL,
+      locationid: `active-client-singlestall-location-${index}`,
+      displayName: `Active Client Singlestall Location ${index}`,
+      clientId: client.id,
+      isSendingAlerts: true,
+      isSendingVitals: true,
+    })
+
+    // create a multistall location for this client that is sending alerts and vitals
+    await factories.locationDBFactory(db, {
+      deviceType: DEVICE_TYPE.DEVICE_SENSOR_MULTISTALL,
+      locationid: `active-client-multistall-location-${index}`,
+      displayName: `Active Client Multistall Location ${index}`,
       clientId: client.id,
       isSendingAlerts: true,
       isSendingVitals: true,
@@ -174,10 +185,21 @@ async function dbInsertInactiveClients() {
     })
 
     if (options.clientHasLocation) {
-      // create a location for this client that is sending alerts and vitals
+      // create a singlestall location for this client that is sending alerts and vitals
       await factories.locationDBFactory(db, {
-        locationid: `inactive-client-location-${index}`,
-        displayName: `Inactive Client Location ${index}`,
+        deviceType: DEVICE_TYPE.DEVICE_SENSOR_SINGLESTALL,
+        locationid: `inactive-client-singlestall-location-${index}`,
+        displayName: `Inactive Client Singlestall Location ${index}`,
+        clientId: client.id,
+        isSendingAlerts: options.locationIsSendingAlerts,
+        isSendingVitals: options.locationIsSendingVitals,
+      })
+
+      // create a multistall location for this client that is sending alerts and vitals
+      await factories.locationDBFactory(db, {
+        deviceType: DEVICE_TYPE.DEVICE_SENSOR_MULTISTALL,
+        locationid: `inactive-client-mutlistall-location-${index}`,
+        displayName: `Inactive Client Multistall Location ${index}`,
         clientId: client.id,
         isSendingAlerts: options.locationIsSendingAlerts,
         isSendingVitals: options.locationIsSendingVitals,

--- a/server/test/unit/vitalsTest/checkHeartbeatTest.js
+++ b/server/test/unit/vitalsTest/checkHeartbeatTest.js
@@ -54,6 +54,9 @@ describe('vitals.js unit tests: checkHeartbeat', () => {
     sandbox.restore()
   })
 
+  // Possibly add seperate test cases here specifially for multistall sensors
+  // Should not matter at all as both are same devices so default singlestall test cases are completely fine
+
   describe('when a device with a firmware state machine and no existing alerts notices that the latest radar message was longer than the threshold', () => {
     beforeEach(async () => {
       const client = factories.clientFactory({ isSendingVitals: true })

--- a/server/test/unit/vitalsTest/checkHeartbeatTest.js
+++ b/server/test/unit/vitalsTest/checkHeartbeatTest.js
@@ -54,9 +54,6 @@ describe('vitals.js unit tests: checkHeartbeat', () => {
     sandbox.restore()
   })
 
-  // Possibly add seperate test cases here specifially for multistall sensors
-  // Should not matter at all as both are same devices so default singlestall test cases are completely fine
-
   describe('when a device with a firmware state machine and no existing alerts notices that the latest radar message was longer than the threshold', () => {
     beforeEach(async () => {
       const client = factories.clientFactory({ isSendingVitals: true })


### PR DESCRIPTION
- Updated **brave-alert-lib to v15.0.4** for deviceType enum change
- Added migration script (migrationID 53) to update device_type_enum to handle multi-stall and single-stall sensors separately.
- Updated device_type_enum to have 'DEVICE_SENSOR_SINGLESTALL' and 'DEVICE_SENSOR_MULTISTALL' instead of 'DEVICE_SENSOR'. <br></br>
- Updated the following db functions: getActiveSensorClients(), getLocations(), createLocationFromBrowserForm(), getDataForExport(), getLocationsFromClientId(), createLocation(), getRecentSensorsVitals() and getRecentSensorsVitalsWithClientId()
- Added functionality to dashboard for submit new location and edit location to handle different device_types using dropdown select 
- Updated test cases for newLocation and updateLocation to use both sensor types
- Wrote new tests for functionality such as inserting a multi-stall sensor and editing single-stall to multi-stall
<hr></hr>

Tests are correctly passing after change to device_type_enum made by the migration script. When merged to dev, the migration script should run allowing for the new test cases to pass. 