### PR TITLE
Add status and commissioned_at column for Sensors (CU-86dv9uxta)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,14 @@ the code was deployed.
 
 - Added `sensorDoorDisconnectionInitial`, `sensorRadarDisconnectionInitial`, `sensorDoorDisconnectionReminder` and `sensorRadarDisconnectionReminder` to english and spanish messages (CU-86duu0vdu).
 - Added functions for the above messages in `vitals.js` (CU-86duu0vdu).
+- Added migration script 54 which adds the `status` and `commissioned_at` column to clients (CU-86dv9uxta).
+- Added new status field in the edit client dashboard page (CU-86dv9uxta).
 
 ### Changed
 
 - Updated `checkHeartbeat` function in `vitals.js` to send the 2 different messages (CU-86duu0vdu).
 - Removed `sendDisconnectionMessage` and `sendDisconnectionReminder`function in `vitals.js` (CU-86duu0vdu).
+- Updated edit client test cases with new status column (CU-86dv9uxta).
 
 ## [10.16.0] - 2024-11-14
 

--- a/server/dashboard.js
+++ b/server/dashboard.js
@@ -468,6 +468,7 @@ const validateEditClient = [
     'isSendingAlerts',
     'isSendingVitals',
     'language',
+    'status',
   ])
     .trim()
     .notEmpty(),
@@ -524,6 +525,7 @@ async function submitEditClient(req, res) {
         data.isSendingAlerts,
         data.isSendingVitals,
         data.language,
+        data.status,
         req.params.id,
       )
 

--- a/server/db/054-status-commissioned-at-columns.sql
+++ b/server/db/054-status-commissioned-at-columns.sql
@@ -1,0 +1,28 @@
+DO $migration$
+    DECLARE migrationId INT;
+    DECLARE lastSuccessfulMigrationId INT;
+BEGIN
+    -- The migration ID of this file
+    migrationId := 54;
+
+    -- Get the migration ID of the last file to be successfully run
+    SELECT MAX(id) INTO lastSuccessfulMigrationId
+    FROM migrations;
+
+    -- Only execute this script if its migration ID is next after the last successful migration ID
+    IF migrationId - lastSuccessfulMigrationId = 1 THEN
+        -- Create ENUM for the new status column
+        CREATE TYPE status_enum AS ENUM ('TESTING', 'SHIPPED', 'LIVE');
+
+        -- Add status column to clients table
+        -- default value is set to LIVE, so cuurent client devices are live 
+        ALTER TABLE clients ADD COLUMN status status_enum NOT NULL DEFAULT 'LIVE';
+
+        -- Add commissioned at column to clients table
+        ALTER TABLE clients ADD COLUMN commissioned_at timestamptz DEFAULT NULL;
+
+        -- Update the migration ID of the last file to be successfully run to the migration ID of this file
+        INSERT INTO migrations (id)
+        VALUES (migrationId);
+    END IF;
+END $migration$;

--- a/server/db/db.js
+++ b/server/db/db.js
@@ -12,8 +12,7 @@ const pool = new pg.Pool({
   user: helpers.getEnvVar('PG_USER'),
   database: helpers.getEnvVar('PG_DATABASE'),
   password: helpers.getEnvVar('PG_PASSWORD'),
-  // ssl: { rejectUnauthorized: false },
-  ssl: false,
+  ssl: { rejectUnauthorized: false },
 })
 
 // 1114 is OID for timestamp in Postgres

--- a/server/db/db.js
+++ b/server/db/db.js
@@ -2,7 +2,7 @@
 const pg = require('pg')
 
 // In-house dependencies
-const { ALERT_TYPE, CHATBOT_STATE, Client, DEVICE_TYPE, Device, Session, helpers } = require('brave-alert-lib')
+const { ALERT_TYPE, CHATBOT_STATE, Client, DEVICE_TYPE, Device, Session, helpers, STATUS } = require('brave-alert-lib')
 const ClientExtension = require('../ClientExtension')
 const SensorsVital = require('../SensorsVital')
 
@@ -12,7 +12,8 @@ const pool = new pg.Pool({
   user: helpers.getEnvVar('PG_USER'),
   database: helpers.getEnvVar('PG_DATABASE'),
   password: helpers.getEnvVar('PG_PASSWORD'),
-  ssl: { rejectUnauthorized: false },
+  // ssl: { rejectUnauthorized: false },
+  ssl: false,
 })
 
 // 1114 is OID for timestamp in Postgres
@@ -58,6 +59,8 @@ function createClientFromRow(r) {
     r.language,
     r.created_at,
     r.updated_at,
+    r.status,
+    r.commissioned_at,
   )
 }
 
@@ -1021,6 +1024,7 @@ async function updateClient(
   isSendingAlerts,
   isSendingVitals,
   language,
+  status,
   clientId,
   pgClient,
 ) {
@@ -1029,8 +1033,8 @@ async function updateClient(
       'updateClient',
       `
       UPDATE clients
-      SET display_name = $1, from_phone_number = $2, responder_phone_numbers = $3, reminder_timeout = $4, fallback_phone_numbers = $5, fallback_timeout = $6, heartbeat_phone_numbers = $7, incident_categories = $8, is_displayed = $9, is_sending_alerts = $10, is_sending_vitals = $11, language = $12
-      WHERE id = $13
+      SET display_name = $1, from_phone_number = $2, responder_phone_numbers = $3, reminder_timeout = $4, fallback_phone_numbers = $5, fallback_timeout = $6, heartbeat_phone_numbers = $7, incident_categories = $8, is_displayed = $9, is_sending_alerts = $10, is_sending_vitals = $11, language = $12, status = $13
+      WHERE id = $14
       RETURNING *
       `,
       [
@@ -1046,6 +1050,7 @@ async function updateClient(
         isSendingAlerts,
         isSendingVitals,
         language,
+        status,
         clientId,
       ],
       pool,
@@ -1224,8 +1229,8 @@ async function createClient(
     const results = await helpers.runQuery(
       'createClient',
       `
-      INSERT INTO clients (display_name, responder_phone_numbers, reminder_timeout, fallback_phone_numbers, from_phone_number, fallback_timeout, heartbeat_phone_numbers, incident_categories, is_displayed, is_sending_alerts, is_sending_vitals, language)
-      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+      INSERT INTO clients (display_name, responder_phone_numbers, reminder_timeout, fallback_phone_numbers, from_phone_number, fallback_timeout, heartbeat_phone_numbers, incident_categories, is_displayed, is_sending_alerts, is_sending_vitals, language, status)
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
       RETURNING *
       `,
       [
@@ -1241,6 +1246,7 @@ async function createClient(
         isSendingAlerts,
         isSendingVitals,
         language,
+        STATUS.TESTING,
       ],
       pool,
       pgClient,

--- a/server/mustache-templates/newClient.mst
+++ b/server/mustache-templates/newClient.mst
@@ -110,21 +110,18 @@
                         <input type="text" class="form-control" name="organization" placeholder="Organization">
                     </div>
                 </div>   
-
                 <div class="form-group row justify-content-start row-no-gutters">
                     <label for="funder" class="col-sm-3 col-form-label">Funder</label>
                     <div class="col-sm-5">
                         <input type="text" class="form-control" name="funder" placeholder="Funder">
                     </div>
                 </div>   
-
                 <div class="form-group row justify-content-start row-no-gutters">
                     <label for="postalCode" class="col-sm-3 col-form-label">Postal Code</label>
                     <div class="col-sm-5">
                         <input type="text" class="form-control" name="postalCode" placeholder="Postal Code">
                     </div>
                 </div>   
-
                 <div class="form-group row justify-content-start row-no-gutters">
                     <label for="city" class="col-sm-3 col-form-label">City</label>
                     <div class="col-sm-5">

--- a/server/mustache-templates/updateClient.mst
+++ b/server/mustache-templates/updateClient.mst
@@ -165,6 +165,20 @@
                         <input type="text" class="form-control" name="project" placeholder="Project" value="{{project}}">
                     </div>
                 </div>
+                <div class="form-group row justify-content-start row-no-gutters">
+                    <label for="clientStatus" class="col-sm-3 col-form-label">Status:</label>
+                    <div class="col-sm-5">
+                        <select class="form-control" id="status" name="status">
+                            <script>
+                            var statusValue = '{{status}}';
+                            document.getElementById('status').innerHTML = `
+                                <option value="TESTING" ${statusValue === 'TESTING' ? 'selected' : ''}>Testing</option>
+                                <option value="SHIPPED" ${statusValue === 'SHIPPED' ? 'selected' : ''}>Shipped</option>
+                                <option value="LIVE" ${statusValue === 'LIVE' ? 'selected' : ''}>Live</option>`
+                            </script>
+                        </select>
+                    </div>
+                </div>
                 <br>
                 <button type="submit" class="btn btn-primary btn-large">Submit</button>
               </form>

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -12,7 +12,7 @@
         "@sentry/node": "^6.2.5",
         "@sentry/tracing": "^6.2.5",
         "axios": "^1.7.4",
-        "brave-alert-lib": "https://github.com/bravetechnologycoop/brave-alert-lib#v15.0.4",
+        "brave-alert-lib": "https://github.com/bravetechnologycoop/brave-alert-lib/#v15.0.5",
         "cookie-parser": "^1.4.5",
         "cors": "^2.8.5",
         "execution-time": "^1.4.1",
@@ -1712,8 +1712,8 @@
       }
     },
     "node_modules/brave-alert-lib": {
-      "version": "15.0.4",
-      "resolved": "git+ssh://git@github.com/bravetechnologycoop/brave-alert-lib.git#cbf910c13810dc8639ca03a1435f2ef93673dd38",
+      "version": "15.0.5",
+      "resolved": "git+ssh://git@github.com/bravetechnologycoop/brave-alert-lib.git#d84cb11cdf2ddfcf489dc367ca8fe8ae60d47389",
       "dependencies": {
         "@sentry/node": "^6.2.5",
         "@sentry/tracing": "^6.2.5",
@@ -3544,22 +3544,19 @@
       }
     },
     "node_modules/gaxios/node_modules/agent-base": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
-      "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
-      "dependencies": {
-        "debug": "^4.3.4"
-      },
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
+      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
       "engines": {
         "node": ">= 14"
       }
     },
     "node_modules/gaxios/node_modules/https-proxy-agent": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.5.tgz",
-      "integrity": "sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
       "dependencies": {
-        "agent-base": "^7.0.2",
+        "agent-base": "^7.1.2",
         "debug": "4"
       },
       "engines": {
@@ -3731,9 +3728,9 @@
       }
     },
     "node_modules/google-auth-library": {
-      "version": "9.14.2",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.14.2.tgz",
-      "integrity": "sha512-R+FRIfk1GBo3RdlRYWPdwk8nmtVUOn6+BkDomAC46KoU8kzXzE1HLmOasSCbWUByMMAGkknVF0G5kQ69Vj7dlA==",
+      "version": "9.15.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.0.tgz",
+      "integrity": "sha512-7ccSEJFDFO7exFbO6NRyC+xH8/mZ1GZGG2xxx9iHxZWcjUjJpjWxIMw3cofAKcueZ6DATiukmmprD7yavQHOyQ==",
       "dependencies": {
         "base64-js": "^1.3.0",
         "ecdsa-sig-formatter": "^1.0.11",

--- a/server/package.json
+++ b/server/package.json
@@ -20,7 +20,7 @@
     "@sentry/node": "^6.2.5",
     "@sentry/tracing": "^6.2.5",
     "axios": "^1.7.4",
-    "brave-alert-lib": "https://github.com/bravetechnologycoop/brave-alert-lib#v15.0.4",
+    "brave-alert-lib": "https://github.com/bravetechnologycoop/brave-alert-lib/#v15.0.5",
     "cookie-parser": "^1.4.5",
     "cors": "^2.8.5",
     "execution-time": "^1.4.1",

--- a/server/test/integration/dashboardTest/submitEditClientTest.js
+++ b/server/test/integration/dashboardTest/submitEditClientTest.js
@@ -55,6 +55,7 @@ describe('dashboard.js integration tests: submitEditClient', () => {
       this.isSendingAlerts = true
       this.isSendingVitals = true
       this.language = 'en'
+      this.status = 'LIVE'
       this.goodRequest = {
         displayName: this.newDisplayname,
         fromPhoneNumber: this.newFromPhoneNumber,
@@ -68,6 +69,7 @@ describe('dashboard.js integration tests: submitEditClient', () => {
         isSendingAlerts: this.isSendingAlerts,
         isSendingVitals: this.isSendingVitals,
         language: this.language,
+        status: this.status,
       }
 
       this.response = await this.agent.post(`/clients/${this.existingClient.id}`).send(this.goodRequest)
@@ -93,6 +95,7 @@ describe('dashboard.js integration tests: submitEditClient', () => {
         isSendingAlerts: updatedClient.isSendingAlerts,
         isSendingVitals: updatedClient.isSendingVitals,
         language: updatedClient.language,
+        status: updatedClient.status,
       }).to.eql({
         displayName: this.newDisplayname,
         fromPhoneNumber: this.newFromPhoneNumber,
@@ -106,6 +109,7 @@ describe('dashboard.js integration tests: submitEditClient', () => {
         isSendingAlerts: this.isSendingAlerts,
         isSendingVitals: this.isSendingVitals,
         language: this.language,
+        status: this.status,
       })
     })
   })
@@ -129,6 +133,7 @@ describe('dashboard.js integration tests: submitEditClient', () => {
       this.isSendingAlerts = '    true    '
       this.isSendingVitals = '    true    '
       this.language = '    en    '
+      this.status = ' LIVE  '
       this.goodRequest = {
         displayName: this.newDisplayname,
         fromPhoneNumber: this.newFromPhoneNumber,
@@ -142,6 +147,7 @@ describe('dashboard.js integration tests: submitEditClient', () => {
         isSendingAlerts: this.isSendingAlerts,
         isSendingVitals: this.isSendingVitals,
         language: this.language,
+        status: this.status,
       }
 
       this.response = await this.agent.post(`/clients/${this.existingClient.id}`).send(this.goodRequest)
@@ -167,6 +173,7 @@ describe('dashboard.js integration tests: submitEditClient', () => {
         isSendingAlerts: updatedClient.isSendingAlerts,
         isSendingVitals: updatedClient.isSendingVitals,
         language: updatedClient.language,
+        status: updatedClient.status,
       }).to.eql({
         displayName: this.newDisplayname.trim(),
         fromPhoneNumber: this.newFromPhoneNumber.trim(),
@@ -180,6 +187,7 @@ describe('dashboard.js integration tests: submitEditClient', () => {
         isSendingAlerts: this.isSendingAlerts.trim() === 'true',
         isSendingVitals: this.isSendingVitals.trim() === 'true',
         language: this.language.trim(),
+        status: this.status.trim(),
       })
     })
   })
@@ -201,6 +209,7 @@ describe('dashboard.js integration tests: submitEditClient', () => {
         isSendingAlerts: 'true',
         isSendingVitals: 'true',
         language: 'en',
+        status: 'LIVE',
       }
 
       this.response = await this.agent.post(`/clients/${this.existingClient.id}`).send(goodRequest)
@@ -239,6 +248,7 @@ describe('dashboard.js integration tests: submitEditClient', () => {
         isSendingAlerts: this.existingClient.isSendingAlerts,
         isSendingVitals: this.existingClient.isSendingVitals,
         language: this.existingClient.language,
+        status: this.existingClient.status,
       }
 
       this.response = await this.agent.post(`/clients/${this.existingClient.id}`).send(this.goodRequest)
@@ -264,6 +274,7 @@ describe('dashboard.js integration tests: submitEditClient', () => {
         isSendingAlerts: updatedClient.isSendingAlerts,
         isSendingVitals: updatedClient.isSendingVitals,
         language: updatedClient.language,
+        status: updatedClient.status,
       }).to.eql({
         displayName: this.existingClient.displayName,
         fromPhoneNumber: this.existingClient.fromPhoneNumber,
@@ -277,6 +288,7 @@ describe('dashboard.js integration tests: submitEditClient', () => {
         isSendingAlerts: this.existingClient.isSendingAlerts,
         isSendingVitals: this.existingClient.isSendingVitals,
         language: this.existingClient.language,
+        status: this.existingClient.status,
       })
     })
   })
@@ -299,6 +311,7 @@ describe('dashboard.js integration tests: submitEditClient', () => {
       this.isSendingAlerts = true
       this.isSendingVitals = true
       this.language = 'en'
+      this.status = 'LIVE'
       this.goodRequest = {
         displayName: this.newDisplayname,
         fromPhoneNumber: this.newFromPhoneNumber,
@@ -311,6 +324,7 @@ describe('dashboard.js integration tests: submitEditClient', () => {
         isSendingAlerts: this.isSendingAlerts,
         isSendingVitals: this.isSendingVitals,
         language: this.language,
+        status: this.status,
       }
 
       this.response = await this.agent.post(`/clients/${this.existingClient.id}`).send(this.goodRequest)
@@ -336,6 +350,7 @@ describe('dashboard.js integration tests: submitEditClient', () => {
         isSendingAlerts: updatedClient.isSendingAlerts,
         isSendingVitals: updatedClient.isSendingVitals,
         language: updatedClient.language,
+        status: updatedClient.status,
       }).to.eql({
         displayName: this.newDisplayname,
         fromPhoneNumber: this.newFromPhoneNumber,
@@ -349,6 +364,7 @@ describe('dashboard.js integration tests: submitEditClient', () => {
         isSendingAlerts: this.isSendingAlerts,
         isSendingVitals: this.isSendingVitals,
         language: this.language,
+        status: this.status,
       })
     })
   })
@@ -371,6 +387,7 @@ describe('dashboard.js integration tests: submitEditClient', () => {
       this.isSendingAlerts = true
       this.isSendingVitals = true
       this.language = 'en'
+      this.status = 'LIVE'
       this.goodRequest = {
         displayName: this.newDisplayname,
         fromPhoneNumber: this.newFromPhoneNumber,
@@ -383,6 +400,7 @@ describe('dashboard.js integration tests: submitEditClient', () => {
         isSendingAlerts: this.isSendingAlerts,
         isSendingVitals: this.isSendingVitals,
         language: this.language,
+        status: this.status,
       }
 
       this.response = await this.agent.post(`/clients/${this.existingClient.id}`).send(this.goodRequest)
@@ -408,6 +426,7 @@ describe('dashboard.js integration tests: submitEditClient', () => {
         isSendingAlerts: updatedClient.isSendingAlerts,
         isSendingVitals: updatedClient.isSendingVitals,
         language: updatedClient.language,
+        status: updatedClient.status,
       }).to.eql({
         displayName: this.newDisplayname,
         fromPhoneNumber: this.newFromPhoneNumber,
@@ -421,6 +440,7 @@ describe('dashboard.js integration tests: submitEditClient', () => {
         isSendingAlerts: this.isSendingAlerts,
         isSendingVitals: this.isSendingVitals,
         language: this.language,
+        status: this.status,
       })
     })
   })
@@ -443,6 +463,7 @@ describe('dashboard.js integration tests: submitEditClient', () => {
       this.isSendingAlerts = true
       this.isSendingVitals = true
       this.language = 'en'
+      this.status = 'LIVE'
       this.goodRequest = {
         displayName: this.newDisplayname,
         fromPhoneNumber: this.newFromPhoneNumber,
@@ -455,6 +476,7 @@ describe('dashboard.js integration tests: submitEditClient', () => {
         isSendingAlerts: this.isSendingAlerts,
         isSendingVitals: this.isSendingVitals,
         language: this.language,
+        status: this.status,
       }
 
       this.response = await this.agent.post(`/clients/${this.existingClient.id}`).send(this.goodRequest)
@@ -495,6 +517,7 @@ describe('dashboard.js integration tests: submitEditClient', () => {
         isSendingAlerts: '',
         isSendingVitals: '',
         language: '',
+        status: '',
       }
 
       this.response = await this.agent.post(`/clients/${this.existingClient.id}`).send(badRequest)
@@ -512,7 +535,7 @@ describe('dashboard.js integration tests: submitEditClient', () => {
 
     it('should log the error', () => {
       expect(helpers.log).to.have.been.calledWith(
-        `Bad request to /clients/${this.existingClient.id}: displayName (Invalid value),responderPhoneNumbers (Invalid value),fromPhoneNumber (Invalid value),incidentCategories (Invalid value),isDisplayed (Invalid value),isSendingAlerts (Invalid value),isSendingVitals (Invalid value),language (Invalid value),reminderTimeout (Invalid value),fallbackTimeout (Invalid value)`,
+        `Bad request to /clients/${this.existingClient.id}: displayName (Invalid value),responderPhoneNumbers (Invalid value),fromPhoneNumber (Invalid value),incidentCategories (Invalid value),isDisplayed (Invalid value),isSendingAlerts (Invalid value),isSendingVitals (Invalid value),language (Invalid value),status (Invalid value),reminderTimeout (Invalid value),fallbackTimeout (Invalid value)`,
       )
     })
   })
@@ -539,7 +562,7 @@ describe('dashboard.js integration tests: submitEditClient', () => {
 
     it('should log the error', () => {
       expect(helpers.log).to.have.been.calledWith(
-        `Bad request to /clients/${this.existingClient.id}: displayName (Invalid value),responderPhoneNumbers (Invalid value),fromPhoneNumber (Invalid value),incidentCategories (Invalid value),isDisplayed (Invalid value),isSendingAlerts (Invalid value),isSendingVitals (Invalid value),language (Invalid value),reminderTimeout (Invalid value),fallbackTimeout (Invalid value)`,
+        `Bad request to /clients/${this.existingClient.id}: displayName (Invalid value),responderPhoneNumbers (Invalid value),fromPhoneNumber (Invalid value),incidentCategories (Invalid value),isDisplayed (Invalid value),isSendingAlerts (Invalid value),isSendingVitals (Invalid value),language (Invalid value),status (Invalid value),reminderTimeout (Invalid value),fallbackTimeout (Invalid value)`,
       )
     })
   })
@@ -565,6 +588,7 @@ describe('dashboard.js integration tests: submitEditClient', () => {
       this.isSendingAlerts = true
       this.isSendingVitals = true
       this.language = 'en'
+      this.status = 'LIVE'
       const duplicateDisplayNameRequest = {
         displayName: this.otherClientName,
         fromPhoneNumber: '+17549553216',
@@ -578,6 +602,7 @@ describe('dashboard.js integration tests: submitEditClient', () => {
         isSendingAlerts: this.isSendingAlerts,
         isSendingVitals: this.isSendingVitals,
         language: this.language,
+        status: this.status,
       }
 
       this.response = await this.agent.post(`/clients/${this.existingClient.id}`).send(duplicateDisplayNameRequest)
@@ -613,6 +638,7 @@ describe('dashboard.js integration tests: submitEditClient', () => {
       this.isSendingAlerts = true
       this.isSendingVitals = true
       this.language = 'en'
+      this.status = 'LIVE'
       this.goodRequest = {
         displayName: this.newDisplayname,
         fromPhoneNumber: this.newFromPhoneNumber,
@@ -626,6 +652,7 @@ describe('dashboard.js integration tests: submitEditClient', () => {
         isSendingAlerts: this.isSendingAlerts,
         isSendingVitals: this.isSendingVitals,
         language: this.language,
+        status: this.status,
       }
 
       this.response = await this.agent.post(`/clients/${this.existingClient.id}`).send(this.goodRequest)
@@ -667,6 +694,7 @@ describe('dashboard.js integration tests: submitEditClient', () => {
       this.isSendingAlerts = true
       this.isSendingVitals = true
       this.language = 'en'
+      this.status = 'LIVE'
       this.goodRequest = {
         displayName: this.newDisplayname,
         fromPhoneNumber: this.newFromPhoneNumber,
@@ -680,6 +708,7 @@ describe('dashboard.js integration tests: submitEditClient', () => {
         isSendingAlerts: this.isSendingAlerts,
         isSendingVitals: this.isSendingVitals,
         language: this.language,
+        status: this.status,
       }
 
       this.response = await this.agent.post(`/clients/${this.existingClient.id}`).send(this.goodRequest)


### PR DESCRIPTION
- Added migration script 54 which adds the `status` and `commissioned_at` column to clients
- Added new status field in the edit client dashboard page 
- Updated edit client test cases with new status column

The commissioned_at column in the database is set to NULL initially when the client is created and status is set to LIVE as default (for existing clients in the database). When a new client is created from the dashboard, the status is set to TESTING by default.