### PR TITLE
Occupant Detection INS Threshold (CU-86dvnjxk7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ the code was deployed.
 ### Added
 
 - Added INS threshold for Occupant Detection, state0 <-> state1 entry/exit condition (CU-86dvnjxk7).
-- Added Initialization procedures for firmware coming from v1924 and v10060 (CU-86dvnjxk7).
+- Added Initialization procedures for firmware coming from v1924 and v10160 (CU-86dvnjxk7).
 - Added `sensorDoorDisconnectionInitial`, `sensorRadarDisconnectionInitial`, `sensorDoorDisconnectionReminder` and `sensorRadarDisconnectionReminder` to english and spanish messages (CU-86duu0vdu).
 - Added functions for the above messages in `vitals.js` (CU-86duu0vdu).
 - Added migration script 54 which adds the `status` and `first_device_live_at` column to clients (CU-86dv9uxta).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ the code was deployed.
 
 ### Added
 
+- Added INS threshold for Occupant Detection, state0 <-> state1 entry/exit condition (CU-86dvnjxk7).
+- Added Initialization procedures for firmware coming from v1924 and v10060 (CU-86dvnjxk7).
 - Added `sensorDoorDisconnectionInitial`, `sensorRadarDisconnectionInitial`, `sensorDoorDisconnectionReminder` and `sensorRadarDisconnectionReminder` to english and spanish messages (CU-86duu0vdu).
 - Added functions for the above messages in `vitals.js` (CU-86duu0vdu).
 - Added migration script 54 which adds the `status` and `first_device_live_at` column to clients (CU-86dv9uxta).
@@ -22,6 +24,7 @@ the code was deployed.
 
 ### Changed
 
+- Names of particle functions to make them (CU-86dvnjx2q).
 - Updated `checkHeartbeat` function in `vitals.js` to send the 2 different messages (CU-86duu0vdu).
 - Removed `sendDisconnectionMessage` and `sendDisconnectionReminder`function in `vitals.js` (CU-86duu0vdu).
 - Updated dashboard homepage to include and sort by Organization (CU-86dva4dxd).
@@ -33,6 +36,7 @@ the code was deployed.
 
 ### Removed
 
+- Removed toggling of GPIO pins in state machine
 - Deleted old CSS code `locationCSSPartial.mst` and `locationFormCSSPartial.mst` (CU-86dup4jg7).
 
 ## [10.16.0] - 2024-11-14

--- a/firmware/boron-ins-fsm/src/BraveSensorProductionFirmware.ino
+++ b/firmware/boron-ins-fsm/src/BraveSensorProductionFirmware.ino
@@ -11,7 +11,7 @@
 #include "tpl5010watchdog.h"
 
 #define DEBUG_LEVEL            LOG_LEVEL_INFO
-#define BRAVE_FIRMWARE_VERSION 1925  // see versioning notes in the readme
+#define BRAVE_FIRMWARE_VERSION 10160  // see versioning notes in the readme
 
 PRODUCT_VERSION(BRAVE_FIRMWARE_VERSION);  // must be an int, see versioning notes above
 SYSTEM_THREAD(ENABLED);

--- a/firmware/boron-ins-fsm/src/BraveSensorProductionFirmware.ino
+++ b/firmware/boron-ins-fsm/src/BraveSensorProductionFirmware.ino
@@ -11,7 +11,7 @@
 #include "tpl5010watchdog.h"
 
 #define DEBUG_LEVEL            LOG_LEVEL_INFO
-#define BRAVE_FIRMWARE_VERSION 10160  // see versioning notes in the readme
+#define BRAVE_FIRMWARE_VERSION 1925  // see versioning notes in the readme
 
 PRODUCT_VERSION(BRAVE_FIRMWARE_VERSION);  // must be an int, see versioning notes above
 SYSTEM_THREAD(ENABLED);

--- a/firmware/boron-ins-fsm/src/consoleFunctions.cpp
+++ b/firmware/boron-ins-fsm/src/consoleFunctions.cpp
@@ -22,14 +22,15 @@
 void setupConsoleFunctions() {
     // particle console function declarations, belongs in setup() as per docs
     Particle.function("Force_Reset", force_reset);
-    Particle.function("Turn_Debugging_Publishes_On_Off", toggle_debugging_publishes);
-    Particle.function("Change_Occupant_Detection_Timer", occupant_detection_timer_set);
-    Particle.function("Change_Initial_Timer", initial_timer_set);
-    Particle.function("Change_Duration_Timer", duration_timer_set);
-    Particle.function("Change_Stillness_Timer", stillness_timer_set);
-    Particle.function("Change_Long_Stillness_Timer", long_stillness_timer_set);
-    Particle.function("Change_INS_Threshold", ins_threshold_set);
-    Particle.function("Change_IM21_Door_ID", im21_door_id_set);
+    Particle.function("Toggle_Debug_Publish", toggle_debugging_publishes);
+    Particle.function("Occupant_Detection_INS_Threshold", occupant_detection_ins_threshold_set);
+    Particle.function("Occupant_Detection_Timer", occupant_detection_timer_set);
+    Particle.function("Initial_Timer", initial_timer_set);
+    Particle.function("Duration_Timer", duration_timer_set);
+    Particle.function("Stillness_Timer", stillness_timer_set);
+    Particle.function("Long_Stillness_Timer", long_stillness_timer_set);
+    Particle.function("Stillness_INS_Threshold", ins_threshold_set);
+    Particle.function("IM21_Door_ID", im21_door_id_set);
     Particle.function("Reset_Stillness_Timer_For_Alerting_Session", reset_stillness_timer_for_alerting_session);
 }
 
@@ -276,8 +277,8 @@ int ins_threshold_set(String input) {
 
     // if e, echo the current threshold
     if (*holder == 'e') {
-        EEPROM.get(ADDR_INS_THRESHOLD, ins_threshold);
-        returnFlag = ins_threshold;
+        EEPROM.get(ADDR_STILLNESS_INS_THRESHOLD, stillness_ins_threshold);
+        returnFlag = stillness_ins_threshold;
     }
     // else parse new threshold
     else {
@@ -292,9 +293,42 @@ int ins_threshold_set(String input) {
             returnFlag = -1;
         }
         else {
-            EEPROM.put(ADDR_INS_THRESHOLD, threshold);
-            ins_threshold = threshold;
-            returnFlag = ins_threshold;
+            EEPROM.put(ADDR_STILLNESS_INS_THRESHOLD, threshold);
+            stillness_ins_threshold = threshold;
+            returnFlag = stillness_ins_threshold;
+        }
+    }
+
+    return returnFlag;
+}
+
+// returns threshold if valid input is given, otherwise returns -1
+int occupant_detection_ins_threshold_set(String input) {
+    int returnFlag = -1;
+
+    const char* holder = input.c_str();
+
+    // if e, echo the current threshold
+    if (*holder == 'e') {
+        EEPROM.get(ADDR_OCCUPATION_INS_THRESHOLD, occupation_detection_ins_threshold);
+        returnFlag = occupation_detection_ins_threshold;
+    }
+    // else parse new threshold
+    else {
+        int threshold = input.toInt();
+
+        if (threshold == 0) {
+            // string.toInt() returns 0 if input not an int
+            // and a threshold value of 0 makes no sense, so return -1
+            returnFlag = -1;
+        }
+        else if (threshold < 0) {
+            returnFlag = -1;
+        }
+        else {
+            EEPROM.put(ADDR_OCCUPATION_INS_THRESHOLD, threshold);
+            occupation_detection_ins_threshold = threshold;
+            returnFlag = occupation_detection_ins_threshold;
         }
     }
 

--- a/firmware/boron-ins-fsm/src/consoleFunctions.h
+++ b/firmware/boron-ins-fsm/src/consoleFunctions.h
@@ -18,6 +18,7 @@ void setupConsoleFunctions();
 // console functions
 int stillness_timer_set(String);
 int long_stillness_timer_set(String);
+int occupant_detection_ins_threshold_set(String);
 int occupant_detection_timer_set(String);
 int initial_timer_set(String);
 int duration_timer_set(String);

--- a/firmware/boron-ins-fsm/src/flashAddresses.h
+++ b/firmware/boron-ins-fsm/src/flashAddresses.h
@@ -21,7 +21,7 @@
 
 // state machine constants
 // all are uint32_t so 4 bytes each
-#define ADDR_INS_THRESHOLD             4
+#define ADDR_STILLNESS_INS_THRESHOLD   4
 #define ADDR_STATE1_MAX_TIME           8
 #define ADDR_STATE2_MAX_DURATION       12
 #define ADDR_STATE3_MAX_STILLNESS_TIME 16
@@ -31,13 +31,20 @@
 #define ADDR_IM_DOORID 20
 
 // new state machine constant and its write originals flag
-#define ADDR_STATE3_MAX_LONG_STILLNESS_TIME                 23  // uint32_t = 4 bytes
-#define ADDR_INITIALIZE_STATE3_MAX_LONG_STILLNESS_TIME_FLAG 27  // uint16_2 = 2 bytes
+#define ADDR_STATE3_MAX_LONG_STILLNESS_TIME                 23 // uint32_t = 4 bytes
+#define ADDR_INITIALIZE_STATE3_MAX_LONG_STILLNESS_TIME_FLAG 27 // uint16_2 = 2 bytes
 
 // new state machine constant for state0 window
-#define ADDR_INITIALIZE_STATE0_OCCUPANT_DETECTION_TIMER_FLAG 29  // uint16_2 = 2 bytes
-#define ADDR_STATE0_OCCUPANT_DETECTION_TIMER                 31  // uint32_t = 4 bytes
+#define ADDR_INITIALIZE_STATE0_OCCUPANT_DETECTION_TIMER_FLAG 29 // uint16_2 = 2 bytes
+#define ADDR_STATE0_OCCUPANT_DETECTION_TIMER                 31 // uint32_t = 4 bytes
 
-// next available address is 31 + 4 = 35
+// memory locations for sensors that had v1924
+#define ADDR_INITIALIZE_HIGH_CONF_INS_THRESHOLD_FLAG         35 // uint16_t = 2 bytes
+#define ADDR_OCCUPATION_INS_THRESHOLD                        37 // uint32_t = 4 bytes
+
+// INS threshold for occupation detection
+#define ADDR_INITIALIZE_OCCUPANCY_DETECTION_INS_THRESHOLD_FLAG 41 // uint16_t = 2 bytes
+
+// next available address is 41 + 2 = 43
 
 #endif

--- a/firmware/boron-ins-fsm/src/stateMachine.cpp
+++ b/firmware/boron-ins-fsm/src/stateMachine.cpp
@@ -130,7 +130,7 @@ void initializeStateMachineConsts() {
 
     if (initializeOccupationDetectionINSThresholdFlag != INITIALIZATION_FLAG_SET) {
         // firmware was never v1924
-        if (initializeHighConfINSThresholdFlag != INITIALIZATION_FLAG_SET) {
+        if (initializeHighConfINSThresholdFlag != INITIALIZATION_FLAG_HIGH_CONF) {
             EEPROM.get(ADDR_STILLNESS_INS_THRESHOLD, occupation_detection_ins_threshold);
             EEPROM.put(ADDR_OCCUPATION_INS_THRESHOLD, occupation_detection_ins_threshold);
             Log.info("State machine constant OccupantDetectionINSThreshold was written to flash on bootup.");
@@ -145,10 +145,9 @@ void initializeStateMachineConsts() {
             EEPROM.put(ADDR_STATE3_MAX_STILLNESS_TIME, state3_max_stillness_time);
             EEPROM.put(ADDR_STATE3_MAX_LONG_STILLNESS_TIME, state3_max_long_stillness_time);
             EEPROM.put(ADDR_OCCUPATION_INS_THRESHOLD, occupation_detection_ins_threshold);
-            Log.info("State machine constant State0OccupationDetectionTimer was written to flash on bootup.");
         }
-        initializeState0OccupationDetectionFlag = INITIALIZATION_FLAG_SET;
-        EEPROM.put(ADDR_INITIALIZE_OCCUPANCY_DETECTION_INS_THRESHOLD_FLAG, initializeState0OccupationDetectionFlag);
+        initializeOccupationDetectionINSThresholdFlag = INITIALIZATION_FLAG_SET;
+        EEPROM.put(ADDR_INITIALIZE_OCCUPANCY_DETECTION_INS_THRESHOLD_FLAG, initializeOccupationDetectionINSThresholdFlag);
     }
     // firmware is v11000+
     else {

--- a/firmware/boron-ins-fsm/src/stateMachine.cpp
+++ b/firmware/boron-ins-fsm/src/stateMachine.cpp
@@ -19,7 +19,8 @@ unsigned long state1_timer;
 unsigned long state2_duration_timer;
 unsigned long state3_stillness_timer;
 // initialize constants to sensible default values
-unsigned long ins_threshold = INS_THRESHOLD;
+unsigned long stillness_ins_threshold = INS_THRESHOLD;
+unsigned long occupation_detection_ins_threshold = INS_THRESHOLD;
 unsigned long state0_occupant_detection_timer = STATE0_OCCUPANT_DETECTION_TIMER;
 unsigned long state1_max_time = STATE1_MAX_TIME;
 unsigned long state2_max_duration = STATE2_MAX_DURATION;
@@ -64,22 +65,24 @@ void initializeStateMachineConsts() {
     uint16_t initializeConstsFlag;
     uint16_t initializeState3MaxLongStillenssTimeFlag;
     uint16_t initializeState0OccupationDetectionFlag;
+    uint16_t initializeHighConfINSThresholdFlag;
+    uint16_t initializeOccupationDetectionINSThresholdFlag;
 
     // Boron flash memory is initialized to all F's (1's)
     EEPROM.get(ADDR_INITIALIZE_SM_CONSTS_FLAG, initializeConstsFlag);
     Log.info("state machine constants flag is 0x%04X", initializeConstsFlag);
 
-    if (initializeConstsFlag != INITIALIZE_STATE_MACHINE_CONSTS_FLAG) {
-        EEPROM.put(ADDR_INS_THRESHOLD, ins_threshold);
+    if (initializeConstsFlag != INITIALIZATION_FLAG_SET) {
+        EEPROM.put(ADDR_STILLNESS_INS_THRESHOLD, stillness_ins_threshold);
         EEPROM.put(ADDR_STATE1_MAX_TIME, state1_max_time);
         EEPROM.put(ADDR_STATE2_MAX_DURATION, state2_max_duration);
         EEPROM.put(ADDR_STATE3_MAX_STILLNESS_TIME, state3_max_stillness_time);
-        initializeConstsFlag = INITIALIZE_STATE_MACHINE_CONSTS_FLAG;
+        initializeConstsFlag = INITIALIZATION_FLAG_SET;
         EEPROM.put(ADDR_INITIALIZE_SM_CONSTS_FLAG, initializeConstsFlag);
         Log.info("State machine constants were written to flash on bootup.");
     }
     else {
-        EEPROM.get(ADDR_INS_THRESHOLD, ins_threshold);
+        EEPROM.get(ADDR_STILLNESS_INS_THRESHOLD, stillness_ins_threshold);
         EEPROM.get(ADDR_STATE1_MAX_TIME, state1_max_time);
         EEPROM.get(ADDR_STATE2_MAX_DURATION, state2_max_duration);
         EEPROM.get(ADDR_STATE3_MAX_STILLNESS_TIME, state3_max_stillness_time);
@@ -89,14 +92,14 @@ void initializeStateMachineConsts() {
     // Boron flash memory is initialized to all F's (1's)
     // Needs separate intialization for Borons that had versions of the firmware <= 9.3.0
     EEPROM.get(ADDR_INITIALIZE_STATE3_MAX_LONG_STILLNESS_TIME_FLAG, initializeState3MaxLongStillenssTimeFlag);
-    Log.info("state machine constant State3MaxLongStillnessTime flag is 0x%04X", initializeState3MaxLongStillenssTimeFlag);
+    Log.info("State3MaxLongStillnessTime flag is 0x%04X", initializeState3MaxLongStillenssTimeFlag);
 
-    if (initializeState3MaxLongStillenssTimeFlag != INITIALIZE_STATE3_MAX_LONG_STILLNESS_TIME_FLAG) {
+    if (initializeState3MaxLongStillenssTimeFlag != INITIALIZATION_FLAG_SET) {
         // By default, we use the same value for max_stillness_time and max_long_stillness_time
         EEPROM.put(ADDR_STATE3_MAX_LONG_STILLNESS_TIME, state3_max_stillness_time);
         state3_max_long_stillness_time = state3_max_stillness_time;
 
-        initializeState3MaxLongStillenssTimeFlag = INITIALIZE_STATE3_MAX_LONG_STILLNESS_TIME_FLAG;
+        initializeState3MaxLongStillenssTimeFlag = INITIALIZATION_FLAG_SET;
         EEPROM.put(ADDR_INITIALIZE_STATE3_MAX_LONG_STILLNESS_TIME_FLAG, initializeState3MaxLongStillenssTimeFlag);
         Log.info("State machine constant State3MaxLongStillnessTime was written to flash on bootup.");
     }
@@ -107,17 +110,49 @@ void initializeStateMachineConsts() {
 
     // Seperate initialization for State 0 Window
     EEPROM.get(ADDR_INITIALIZE_STATE0_OCCUPANT_DETECTION_TIMER_FLAG, initializeState0OccupationDetectionFlag);
-    Log.info("state machine constant State0OccupationDetectionFlag is 0x%04X", initializeState0OccupationDetectionFlag);
+    Log.info("State0OccupationDetectionFlag is 0x%04X", initializeState0OccupationDetectionFlag);
 
-    if (initializeState0OccupationDetectionFlag != INITIALIZE_STATE0_OCCUPANT_DETECTION_FLAG) {
+    if (initializeState0OccupationDetectionFlag != INITIALIZATION_FLAG_SET) {
         EEPROM.put(ADDR_STATE0_OCCUPANT_DETECTION_TIMER, state0_occupant_detection_timer);
-        initializeState0OccupationDetectionFlag = INITIALIZE_STATE0_OCCUPANT_DETECTION_FLAG;
+        initializeState0OccupationDetectionFlag = INITIALIZATION_FLAG_SET;
         EEPROM.put(ADDR_INITIALIZE_STATE0_OCCUPANT_DETECTION_TIMER_FLAG, initializeState0OccupationDetectionFlag);
         Log.info("State machine constant State0OccupationDetectionTimer was written to flash on bootup.");
     }
     else {
         EEPROM.get(ADDR_STATE0_OCCUPANT_DETECTION_TIMER, state0_occupant_detection_timer);
         Log.info("State machine constant State0OccupationDetectionTimer was read from flash on bootup.");
+    }
+
+    // Initialization for Occupation Detection INS threshold
+    EEPROM.get(ADDR_INITIALIZE_OCCUPANCY_DETECTION_INS_THRESHOLD_FLAG, initializeOccupationDetectionINSThresholdFlag);
+    EEPROM.get(ADDR_INITIALIZE_HIGH_CONF_INS_THRESHOLD_FLAG, initializeHighConfINSThresholdFlag);
+    Log.info("OccupationDetectionINSThresholdFlag is 0x%04X", initializeOccupationDetectionINSThresholdFlag);
+
+    if (initializeOccupationDetectionINSThresholdFlag != INITIALIZATION_FLAG_SET) {
+        // firmware was never v1924
+        if (initializeHighConfINSThresholdFlag != INITIALIZATION_FLAG_SET) {
+            EEPROM.get(ADDR_STILLNESS_INS_THRESHOLD, occupation_detection_ins_threshold);
+            EEPROM.put(ADDR_OCCUPATION_INS_THRESHOLD, occupation_detection_ins_threshold);
+            Log.info("State machine constant OccupantDetectionINSThreshold was written to flash on bootup.");
+        }
+        // firmware was previously v1924
+        else {
+            EEPROM.get(ADDR_STATE3_MAX_LONG_STILLNESS_TIME, state3_max_stillness_time);
+            EEPROM.get(ADDR_STATE3_MAX_STILLNESS_TIME, state3_max_long_stillness_time);
+            EEPROM.get(ADDR_STILLNESS_INS_THRESHOLD, occupation_detection_ins_threshold);
+            EEPROM.get(ADDR_OCCUPATION_INS_THRESHOLD, stillness_ins_threshold);
+            EEPROM.put(ADDR_STILLNESS_INS_THRESHOLD, stillness_ins_threshold);
+            EEPROM.put(ADDR_STATE3_MAX_STILLNESS_TIME, state3_max_stillness_time);
+            EEPROM.put(ADDR_STATE3_MAX_LONG_STILLNESS_TIME, state3_max_long_stillness_time);
+            EEPROM.put(ADDR_OCCUPATION_INS_THRESHOLD, occupation_detection_ins_threshold);
+            Log.info("State machine constant State0OccupationDetectionTimer was written to flash on bootup.");
+        }
+        initializeState0OccupationDetectionFlag = INITIALIZATION_FLAG_SET;
+        EEPROM.put(ADDR_INITIALIZE_OCCUPANCY_DETECTION_INS_THRESHOLD_FLAG, initializeState0OccupationDetectionFlag);
+    }
+    // firmware is v11000+
+    else {
+        EEPROM.get(ADDR_OCCUPATION_INS_THRESHOLD, occupation_detection_ins_threshold);
     }
 }
 
@@ -145,18 +180,12 @@ void state0_idle() {
     // set the total number of alerts generated to 0
     number_of_alerts_published = 0;
 
-    // do stuff in the state
-    digitalWrite(D2, LOW);
-    digitalWrite(D3, LOW);
-    digitalWrite(D4, LOW);
-    digitalWrite(D5, LOW);
-
     Log.info("You are in state 0, idle: Door status, iAverage = 0x%02X, %f", checkDoor.doorStatus, checkINS.iAverage);
     // default timer to 0 when state doesn't have a timer
     publishDebugMessage(0, checkDoor.doorStatus, checkINS.iAverage, (millis() - timeWhenDoorClosed));
 
     // fix outputs and state exit conditions accordingly
-    if (millis() - timeWhenDoorClosed < state0_occupant_detection_timer && ((unsigned long)checkINS.iAverage > ins_threshold) &&
+    if (millis() - timeWhenDoorClosed < state0_occupant_detection_timer && ((unsigned long)checkINS.iAverage > occupation_detection_ins_threshold) &&
         !isDoorOpen(checkDoor.doorStatus) && !isDoorStatusUnknown(checkDoor.doorStatus)) {
         Log.warn("In state 0, door closed and seeing movement, heading to state 1");
         publishStateTransition(0, 1, checkDoor.doorStatus, checkINS.iAverage);
@@ -184,13 +213,12 @@ void state1_15sCountdown() {
     checkINS = checkINS3331();
 
     // do stuff in the state
-    digitalWrite(D2, HIGH);
     Log.info("You are in state 1, initial countdown: Door status, iAverage, timer = 0x%02X, %f, %ld", checkDoor.doorStatus, checkINS.iAverage,
              (millis() - state1_timer));
     publishDebugMessage(1, checkDoor.doorStatus, checkINS.iAverage, (millis() - state1_timer));
 
     // fix outputs and state exit conditions accordingly
-    if ((unsigned long)checkINS.iAverage > 0 && (unsigned long)checkINS.iAverage < ins_threshold) {
+    if ((unsigned long)checkINS.iAverage > 0 && (unsigned long)checkINS.iAverage < occupation_detection_ins_threshold) {
         Log.warn("no movement, you're going back to state 0 from state 1");
         publishStateTransition(1, 0, checkDoor.doorStatus, checkINS.iAverage);
         saveStateChangeOrAlert(1, 1);
@@ -230,13 +258,12 @@ void state2_duration() {
     char alertMessage[622];
 
     // do stuff in the state
-    digitalWrite(D3, HIGH);
     Log.info("You are in state 2, duration: Door status, iAverage, timer = 0x%02X, %f, %ld", checkDoor.doorStatus, checkINS.iAverage,
              (millis() - state2_duration_timer));
     publishDebugMessage(2, checkDoor.doorStatus, checkINS.iAverage, (millis() - state2_duration_timer));
 
     // fix outputs and state exit conditions accordingly
-    if ((unsigned long)checkINS.iAverage > 0 && (unsigned long)checkINS.iAverage < ins_threshold) {
+    if ((unsigned long)checkINS.iAverage > 0 && (unsigned long)checkINS.iAverage < stillness_ins_threshold) {
         Log.warn("Seeing stillness, going to state3_stillness from state2_duration");
         publishStateTransition(2, 3, checkDoor.doorStatus, checkINS.iAverage);
         saveStateChangeOrAlert(2, 1);
@@ -283,13 +310,12 @@ void state3_stillness() {
     checkINS = checkINS3331();
 
     // do stuff in the state
-    digitalWrite(D4, HIGH);
     Log.info("You are in state 3, stillness: Door status, iAverage, timer = 0x%02X, %f, %ld", checkDoor.doorStatus, checkINS.iAverage,
              (millis() - state3_stillness_timer));
     publishDebugMessage(3, checkDoor.doorStatus, checkINS.iAverage, (millis() - state3_stillness_timer));
 
     // fix outputs and state exit conditions accordingly
-    if ((unsigned long)checkINS.iAverage > ins_threshold) {
+    if ((unsigned long)checkINS.iAverage > stillness_ins_threshold) {
         Log.warn("motion spotted again, going from state3_stillness to state2_duration");
         publishStateTransition(3, 2, checkDoor.doorStatus, checkINS.iAverage);
         saveStateChangeOrAlert(3, 0);
@@ -354,9 +380,9 @@ void publishDebugMessage(int state, unsigned char doorStatus, float INSValue, un
             // from particle docs, max length of publish is 622 chars, I am assuming this includes null char
             char debugMessage[622];
             snprintf(debugMessage, sizeof(debugMessage),
-                     "{\"state\":\"%d\", \"door_status\":\"0x%02X\", \"INS_val\":\"%f\", \"INS_threshold\":\"%lu\", \"timer_status\":\"%lu\", "
+                     "{\"state\":\"%d\", \"door_status\":\"0x%02X\", \"INS_val\":\"%f\", \"occupation_detection_threshold\":\"%lu\", \"stillness_threshold\":\"%lu\", \"timer_status\":\"%lu\", "
                      "\"occupation_detection_timer\":\"%lu\", \"initial_timer\":\"%lu\", \"duration_timer\":\"%lu\", \"stillness_timer\":\"%lu\"}",
-                     state, doorStatus, INSValue, ins_threshold, timer, state0_occupant_detection_timer, state1_max_time, state2_max_duration,
+                     state, doorStatus, INSValue, occupation_detection_ins_threshold, stillness_ins_threshold, timer, state0_occupant_detection_timer, state1_max_time, state2_max_duration,
                      *max_stillness_time);
             Particle.publish("Debug Message", debugMessage, PRIVATE);
             lastDebugPublish = millis();

--- a/firmware/boron-ins-fsm/src/stateMachine.h
+++ b/firmware/boron-ins-fsm/src/stateMachine.h
@@ -10,17 +10,15 @@
 
 // ascii table goes up to 7F, so pick something greater than that
 // which is also unlikely to be part of a door ID or a threshold/timer const
-#define INITIALIZE_STATE_MACHINE_CONSTS_FLAG           0x8888
-#define INITIALIZE_STATE3_MAX_LONG_STILLNESS_TIME_FLAG 0x8888
-#define INITIALIZE_STATE0_OCCUPANT_DETECTION_FLAG      0x8888
+#define INITIALIZATION_FLAG_SET 0x8888
 
 // initial (default) values for state machine, can be changed via console function
 // or by writing something other than 0x8888 to the above flag in flash
 #define INS_THRESHOLD                   60
-#define STATE0_OCCUPANT_DETECTION_TIMER 172800000  // 2 days
-#define STATE1_MAX_TIME                 15000      // ms = 15s
-#define STATE2_MAX_DURATION             1200000    // ms = 20 min
-#define STATE3_MAX_STILLNESS_TIME       120000     // ms = 2 minutes
+#define STATE0_OCCUPANT_DETECTION_TIMER 60000      // 1 min
+#define STATE1_MAX_TIME                 5000       // 5 s
+#define STATE2_MAX_DURATION             1200000    // 20 min
+#define STATE3_MAX_STILLNESS_TIME       180000     // 3 min
 
 // How often to publish Heartbeat messages
 #define SM_HEARTBEAT_INTERVAL 660000  // ms = 11 min
@@ -71,7 +69,8 @@ extern unsigned long state2_duration_timer;
 extern unsigned long state3_stillness_timer;
 
 // state machine constants stored in flash
-extern unsigned long ins_threshold;
+extern unsigned long stillness_ins_threshold;
+extern unsigned long occupation_detection_ins_threshold;
 extern unsigned long state0_occupant_detection_timer;
 extern unsigned long state1_max_time;
 extern unsigned long state2_max_duration;

--- a/firmware/boron-ins-fsm/src/stateMachine.h
+++ b/firmware/boron-ins-fsm/src/stateMachine.h
@@ -10,7 +10,8 @@
 
 // ascii table goes up to 7F, so pick something greater than that
 // which is also unlikely to be part of a door ID or a threshold/timer const
-#define INITIALIZATION_FLAG_SET 0x8888
+#define INITIALIZATION_FLAG_SET       0x8888
+#define INITIALIZATION_FLAG_HIGH_CONF 0x9999
 
 // initial (default) values for state machine, can be changed via console function
 // or by writing something other than 0x8888 to the above flag in flash

--- a/firmware/boron-ins-fsm/test/base.h
+++ b/firmware/boron-ins-fsm/test/base.h
@@ -35,4 +35,5 @@ long unsigned state1_max_time;
 long unsigned state2_max_duration;
 long unsigned state3_max_stillness_time;
 long unsigned state3_max_long_stillness_time;
-long unsigned ins_threshold;
+long unsigned stillness_ins_threshold;
+long unsigned occupation_detection_ins_threshold;

--- a/firmware/boron-ins-fsm/test/consoleFunctionTests.cpp
+++ b/firmware/boron-ins-fsm/test/consoleFunctionTests.cpp
@@ -417,15 +417,15 @@ SCENARIO("Set Long Stillness Timer", "[long stillness timer]") {
     }
 }
 
-SCENARIO("Set INS Threshold", "[ins threshold]") {
+SCENARIO("Set Stillness INS Threshold", "[stillness threshold]") {
     GIVEN("A starting initial threshold of 10") {
-        ins_threshold = 10;
+        stillness_ins_threshold = 10;
 
         WHEN("the function is called with 'e'") {
             int returnFlag = ins_threshold_set("e");
 
             THEN("the initial timer value should remain the same") {
-                REQUIRE(ins_threshold == 10);
+                REQUIRE(stillness_ins_threshold == 10);
             }
 
             THEN("the function should return the stored value") {
@@ -437,7 +437,7 @@ SCENARIO("Set INS Threshold", "[ins threshold]") {
             int returnFlag = ins_threshold_set("15");
 
             THEN("the initial timer value should be updated to the input") {
-                REQUIRE(ins_threshold == 15);
+                REQUIRE(stillness_ins_threshold == 15);
             }
 
             THEN("the function should return the input") {
@@ -449,7 +449,7 @@ SCENARIO("Set INS Threshold", "[ins threshold]") {
             int returnFlag = ins_threshold_set("-15");
 
             THEN("the initial timer value should not be updated") {
-                REQUIRE(ins_threshold == 10);
+                REQUIRE(stillness_ins_threshold == 10);
             }
 
             THEN("the function should return -1 to indicate an error") {
@@ -461,7 +461,61 @@ SCENARIO("Set INS Threshold", "[ins threshold]") {
             int returnFlag = ins_threshold_set("nonint");
 
             THEN("the initial timer value should not be updated") {
-                REQUIRE(ins_threshold == 10);
+                REQUIRE(stillness_ins_threshold == 10);
+            }
+
+            THEN("the function should return -1 to indicate an error") {
+                REQUIRE(returnFlag == -1);
+            }
+        }
+    }
+}
+
+SCENARIO("Set Occupation Detection INS Threshold", "[occupation detection threshold]") {
+    GIVEN("A starting initial threshold of 10") {
+        occupation_detection_ins_threshold = 10;
+
+        WHEN("the function is called with 'e'") {
+            int returnFlag = occupant_detection_ins_threshold_set("e");
+
+            THEN("the initial timer value should remain the same") {
+                REQUIRE(occupation_detection_ins_threshold == 10);
+            }
+
+            THEN("the function should return the stored value") {
+                REQUIRE(occupation_detection_ins_threshold == 10);
+            }
+        }
+
+        WHEN("the function is called with a positive integer") {
+            int returnFlag = occupant_detection_ins_threshold_set("15");
+
+            THEN("the initial timer value should be updated to the input") {
+                REQUIRE(occupation_detection_ins_threshold == 15);
+            }
+
+            THEN("the function should return the input") {
+                REQUIRE(occupation_detection_ins_threshold == 15);
+            }
+        }
+
+        WHEN("the function is called with a negative integer") {
+            int returnFlag = occupant_detection_ins_threshold_set("-15");
+
+            THEN("the initial timer value should not be updated") {
+                REQUIRE(occupation_detection_ins_threshold == 10);
+            }
+
+            THEN("the function should return -1 to indicate an error") {
+                REQUIRE(returnFlag == -1);
+            }
+        }
+
+        WHEN("the function is called with something other than 'e' or a positive integer") {
+            int returnFlag = occupant_detection_ins_threshold_set("nonint");
+
+            THEN("the initial timer value should not be updated") {
+                REQUIRE(occupation_detection_ins_threshold == 10);
             }
 
             THEN("the function should return -1 to indicate an error") {


### PR DESCRIPTION
This is replacing the High/Low Confidence thresholds with the main difference being that "low confidence" stillness is being removed and "High Confidence" stillness is the default stillness. The "low confidence" threshold will remain as the entry condition for occupation

The firmware update must account for High/Low Confidence settings that are already tuned in production devices that have fw version 1924.

If the firmware that is updated did not have high/low confidence tunings, set the default occupant detection threshold to the same value as the INS threshold

Test Plan:
___

Initialization:
- [x] flash boron with v1924
- [x] set High Confidence Threshold to 20, Low Confidence Threshold to 100, HC timer to 120 and LC timer to 300
- [x] flash boron with new firmware
- [x] ensure that stillness_INS_threshold is 20, occupant_detection_INS_threshold is 100, stillness_timer is 120 and long_stillness_timer is 300
- [x] ensure that no other eeprom location is altered (eg. initial timer, door contact id)
- [x] reset EEPROM
- [x] flash new firmware
- [x] ensure that stillness_INS_threshold = occupation_detection_INS_threshold

Functionality:

- [x] set occupant_detection_threshold to 1000
- [x] set stillness_INS_threshold to 20
- [x] set initial_timer to 5s
- [x] close door and wave in front of sensor (such that INS < 1000)
- [x] ensure that FSM stays in state 0
- [x] shake sensor (such that INS > 1000) for 5 s
- [x] ensure that state 1 is entered
- [x] stop moving (such that INS < 20)
- [x] ensure that state 3 is entered
- [x] wave in front of sensor (such that INS > 20)
- [x] ensure that state 2 is entered