### PR TITLE
Smoketest fix (CU-86dwn7ren)

### DIFF
--- a/server/src/db/db_new.js
+++ b/server/src/db/db_new.js
@@ -757,7 +757,7 @@ async function getStillnessSurveyFollowupDelay(clientId, pgClient) {
 }
 
 async function clearClientWithClientId(clientId, pgClient) {
-  if (!helpers.isTestEnvironment()) {
+  if (!helpers.isTestEnvironment() && !helpers.isStagingEnvironment()) {
     helpers.log('Warning - tried to clear client outside of a test environment!')
     return
   }

--- a/server/src/utils/helpers.js
+++ b/server/src/utils/helpers.js
@@ -21,6 +21,10 @@ function isTestEnvironment() {
   return process.env.NODE_ENV === 'test'
 }
 
+function isStagingEnvironment() {
+  return process.env.NODE_ENV === 'staging'
+}
+
 function isDbLogging() {
   return process.env.IS_DB_LOGGING === 'true'
 }
@@ -181,6 +185,7 @@ module.exports = {
   getEnvVar,
   isDbLogging,
   isTestEnvironment,
+  isStagingEnvironment,
   isValidRequest,
   log,
   logError,


### PR DESCRIPTION
There was a bug where the teardown wouldn't run in the smoketest due to it being in a 'staging' environment, and removing a client via code is restricted to test environment. Code now allows the teardown to run in the staging environment.