### PR TITLE
Add opt-in occupancy event publishing

### DIFF
--- a/firmware/boron-ins-fsm/src/consoleFunctions.cpp
+++ b/firmware/boron-ins-fsm/src/consoleFunctions.cpp
@@ -484,13 +484,13 @@ int toggle_occupancy_events(String command) {
     else if (*holder == '1') {
         returnFlag = 1;
         occupancyEventsEnabled = true;
-        EEPROM.put(ADDR_OCCUPANCY_EVENTS_ENABLED, (uint8_t)1);
+        EEPROM.put(ADDR_OCCUPANCY_EVENTS_ENABLED, (bool)true);
         Particle.publish("Occupancy Events Enabled", "true", PRIVATE);
     }
     else if (*holder == '0') {
         returnFlag = 0;
         occupancyEventsEnabled = false;
-        EEPROM.put(ADDR_OCCUPANCY_EVENTS_ENABLED, (uint8_t)0);
+        EEPROM.put(ADDR_OCCUPANCY_EVENTS_ENABLED, (bool)false);
         Particle.publish("Occupancy Events Disabled", "false", PRIVATE);
     }
     else if (*holder == 'e') {

--- a/firmware/boron-ins-fsm/src/consoleFunctions.cpp
+++ b/firmware/boron-ins-fsm/src/consoleFunctions.cpp
@@ -28,6 +28,7 @@ void setupConsoleFunctions() {
     Particle.function("Stillness_Time", stillness_alert_time_set);
 
     Particle.function("IM21_Door_ID", im21_door_id_set);
+    Particle.function("Toggle_Occupancy_Events", toggle_occupancy_events);
 }
 
 int force_reset(String command) {
@@ -466,5 +467,37 @@ int im21_door_id_set(String command) {
 
     // return door ID as int
     return (int)strtol(buffer, NULL, 16);
+}
+
+int toggle_occupancy_events(String command) {
+    // default to invalid input
+    int returnFlag = -1;
+
+    // string.toInt() returns 0 if it fails, so can't distinguish between user
+    // entering 0 vs entering bad input. So convert to char and use ascii table
+    const char* holder = command.c_str();
+
+    if (*(holder + 1) != 0) {
+        // any string longer than 1 char is invalid input
+        returnFlag = -1;
+    }
+    else if (*holder == '1') {
+        returnFlag = 1;
+        occupancyEventsEnabled = true;
+        EEPROM.put(ADDR_OCCUPANCY_EVENTS_ENABLED, (uint8_t)1);
+        Particle.publish("Occupancy Events Enabled", "true", PRIVATE);
+    }
+    else if (*holder == '0') {
+        returnFlag = 0;
+        occupancyEventsEnabled = false;
+        EEPROM.put(ADDR_OCCUPANCY_EVENTS_ENABLED, (uint8_t)0);
+        Particle.publish("Occupancy Events Disabled", "false", PRIVATE);
+    }
+    else if (*holder == 'e') {
+        // Return current status
+        returnFlag = occupancyEventsEnabled ? 1 : 0;
+    }
+
+    return returnFlag;
 }
 

--- a/firmware/boron-ins-fsm/src/consoleFunctions.h
+++ b/firmware/boron-ins-fsm/src/consoleFunctions.h
@@ -29,4 +29,6 @@ int stillness_alert_time_set(String);
 
 int im21_door_id_set(String);
 
+int toggle_occupancy_events(String);
+
 #endif

--- a/firmware/boron-ins-fsm/src/debugFlags.cpp
+++ b/firmware/boron-ins-fsm/src/debugFlags.cpp
@@ -13,3 +13,5 @@ unsigned long debugFlagTurnedOnAt;
 // Initialize constants to sensible defaults. This will be overwritten
 bool stateMachineDebugFlag = false;
 unsigned long lastDebugPublish = 0;
+bool occupancyEventsEnabled = false;
+unsigned long lastOccupancyEventPublish = 0;

--- a/firmware/boron-ins-fsm/src/debugFlags.h
+++ b/firmware/boron-ins-fsm/src/debugFlags.h
@@ -23,4 +23,10 @@ extern unsigned long debugFlagTurnedOnAt;
 // The value of millis() at the time of the most recent debug publish
 extern unsigned long lastDebugPublish;
 
+// Whether or not to publish occupancy events
+extern bool occupancyEventsEnabled;
+
+// The value of millis() at the time of the most recent occupancy event publish
+extern unsigned long lastOccupancyEventPublish;
+
 #endif

--- a/firmware/boron-ins-fsm/src/flashAddresses.h
+++ b/firmware/boron-ins-fsm/src/flashAddresses.h
@@ -44,4 +44,7 @@
 
 // next available address is 41 + 4 = 45
 
+// Occupancy events enabled flag (1 byte)
+#define ADDR_OCCUPANCY_EVENTS_ENABLED 45
+
 #endif

--- a/firmware/boron-ins-fsm/src/stateMachine.h
+++ b/firmware/boron-ins-fsm/src/stateMachine.h
@@ -103,4 +103,6 @@ void state3_stillness();
 void publishDebugMessage(int, unsigned char, float, unsigned long);
 void publishStateTransition(int, int, unsigned char, float);
 
+void publishOccupancyEvent(bool occupied, int state, unsigned char doorStatus, float insValue);
+
 #endif


### PR DESCRIPTION
This PR adds a new opt-in feature that publishes occupancy state changes to the Particle cloud, enabling real-time awareness of space usage via webhooks/streams.

## New Features

- **Toggle_Occupancy_Events** console function to enable/disable the feature (opt-in, default: disabled)
- Publishes &#39;Occupancy Changed&#39; events when occupancy state changes:
  - **Occupied**: State 0→1 (initial detection) and State 1→2 (confirmed occupancy)
  - **Not occupied**: State 2→0 and State 3→0 (door opened, session ended)

## Event Payload

```json
{
  "occupied": "true",
  "state": "2",
  "door_status": "0x08",
  "INS_val": "15.300000",
  "timestamp": "123456789"
}
```

## Data Usage

- Only publishes on state changes (not periodic)
- ~80 bytes per event
- Typical usage: 2-4 events per bathroom session
- Minimal impact on data plan

## Usage

1. Call &#39;Toggle_Occupancy_Events&#39; with "1" to enable (persists to EEPROM)
2. Call with "0" to disable
3. Call with "e" to check current status

## Files Changed

- &#39;flashAddresses.h&#39; - Added EEPROM address for occupancy events flag
- &#39;debugFlags.h/cpp&#39; - Added occupancy events flag and timestamp
- &#39;consoleFunctions.h/cpp&#39; - Added Toggle_Occupancy_Events console function
- &#39;stateMachine.h/cpp&#39; - Added publishOccupancyEvent() and calls at state transitions
- &#39;BraveSensorProductionFirmware.ino&#39; - Bumped version to 12028

## Safety Considerations

- Feature is **opt-in and disabled by default**
- Setting persists to EEPROM (survives reboots)
- Rate limited to 1 publish per 500ms to prevent data overage
- No impact on existing alert functionality

## Testing

- [ ] Test Toggle_Occupancy_Events console function
- [ ] Verify events publish on state transitions
- [ ] Verify setting persists after reboot
- [ ] Verify no events published when disabled
- [ ] Verify rate limiting works