### PR TITLE
Catch pg client connection errors + add synchronous crash logging

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -2,10 +2,15 @@
 const express = require('express')
 
 // In-house dependencies
+const { installCrashLogging } = require('./src/utils/crashLogging')
 const i18nextSetup = require('./src/utils/i18nextSetup')
 const { setupMiddleware } = require('./src/utils/middlewareSetup')
 const { setupRoutes } = require('./src/utils/routeSetup')
 const { setupServer } = require('./src/utils/serverSetup')
+
+// Register fatal-error handlers before anything else so a synchronous stderr
+// record is written even if Sentry's async delivery is lost on a hard kill.
+installCrashLogging()
 
 i18nextSetup.setup()
 

--- a/server/src/db/db.js
+++ b/server/src/db/db.js
@@ -30,11 +30,20 @@ pool.on('error', err => {
 
 let activeConnections = 0
 
-pool.on('connect', () => {
+pool.on('connect', client => {
   activeConnections += 1
   if (helpers.isDbLogging()) {
     helpers.log(`[${new Date().toISOString()}] New connection established. Active: ${activeConnections}`)
   }
+  // Handle connection-level errors on the checked-out client. Without this, an
+  // unexpected termination (e.g. Postgres closing a connection that exceeded
+  // idle_in_transaction_session_timeout while an external call was held inside a
+  // transaction) surfaces as an unhandled 'error' event -> uncaughtException ->
+  // process exit(1). pool.on('error') above does NOT cover checked-out clients.
+  // Attached once per physical connection, so no listener accumulation on reuse.
+  client.on('error', err => {
+    helpers.logError(`Database client connection error: ${err.message}`)
+  })
 })
 
 pool.on('release', () => {

--- a/server/src/utils/crashLogging.js
+++ b/server/src/utils/crashLogging.js
@@ -1,0 +1,37 @@
+/*
+ * crashLogging.js
+ *
+ * Guarantees a synchronous stderr record of fatal process errors before the
+ * process exits.
+ *
+ * Sentry (see helpers.setupSentry) already captures uncaughtException /
+ * unhandledRejection, but its delivery is asynchronous and can be lost if the
+ * container is killed mid-flush -- which is why fatal crashes have been showing
+ * up as clean cut-offs in CloudWatch with no stack trace. A synchronous
+ * fs.writeSync to fd 2 (stderr) always lands in the log stream before exit.
+ *
+ * Log-only by design: it does NOT call process.exit, so Sentry's own handlers
+ * retain control of flushing and terminating the process. Handlers are
+ * registered before Sentry.init so this synchronous line is written first.
+ */
+
+const fs = require('fs')
+
+function writeFatal(kind, err, extra) {
+  try {
+    const stack = (err && err.stack) || String(err)
+    const suffix = extra ? ` (${extra})` : ''
+    fs.writeSync(2, `[${new Date().toISOString()}] FATAL ${kind}${suffix}: ${stack}\n`)
+  } catch (_) {
+    // A crash handler must never throw.
+  }
+}
+
+function installCrashLogging() {
+  process.on('uncaughtException', (err, origin) => writeFatal('uncaughtException', err, origin))
+  process.on('unhandledRejection', reason => writeFatal('unhandledRejection', reason))
+}
+
+module.exports = {
+  installCrashLogging,
+}


### PR DESCRIPTION
Prevents the recurring idle-in-transaction crash from killing the process. When Postgres terminates a checked-out connection (e.g. a transaction held open past idle_in_transaction_session_timeout while awaiting a slow Twilio/Teams send), the client emits an 'error' event. Previously nothing listened for it on a checked-out client (pool.on('error') only covers idle pool clients), so it became an unhandled 'error' -> uncaughtException -> process exit(1) and a 2-3 min outage while ECS replaced the task.

- db.js: attach client.on('error') in pool.on('connect') (once per physical connection) so the termination is logged ("Database client connection error: ...") and handled instead of crashing the process. The in-flight request still fails and rolls back, but the process stays up.
- crashLogging.js + index.js: install process-level uncaughtException / unhandledRejection handlers that write the stack synchronously to stderr (fs.writeSync), so any future fatal error is captured in CloudWatch even if Sentry's async delivery is lost on exit.

This is a safety net that stops the outages regardless of which code path still holds a send inside a transaction; the remaining in-transaction sends in eventHandlers.js will be moved out separately.